### PR TITLE
statediff: Use a worker pool

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -191,8 +191,17 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 			} else {
 				utils.Fatalf("Must specify client name for statediff DB output")
 			}
+		} else {
+			if ctx.GlobalBool(utils.StateDiffWritingFlag.Name) {
+				utils.Fatalf("Must pass DB parameters if enabling statediff write loop")
+			}
 		}
-		utils.RegisterStateDiffService(stack, backend, dbParams, ctx.GlobalBool(utils.StateDiffWritingFlag.Name))
+		params := statediff.ServiceParams{
+			DBParams:        dbParams,
+			EnableWriteLoop: ctx.GlobalBool(utils.StateDiffWritingFlag.Name),
+			NumWorkers:      ctx.GlobalUint(utils.StateDiffWorkersFlag.Name),
+		}
+		utils.RegisterStateDiffService(stack, backend, params)
 	}
 
 	// Configure GraphQL if requested

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -162,6 +162,7 @@ var (
 		utils.StateDiffDBNodeIDFlag,
 		utils.StateDiffDBClientNameFlag,
 		utils.StateDiffWritingFlag,
+		utils.StateDiffWorkersFlag,
 		configFileFlag,
 	}
 

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -242,6 +242,7 @@ var AppHelpFlagGroups = []flags.FlagGroup{
 			utils.StateDiffDBNodeIDFlag,
 			utils.StateDiffDBClientNameFlag,
 			utils.StateDiffWritingFlag,
+			utils.StateDiffWorkersFlag,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -746,6 +746,10 @@ var (
 		Name:  "statediff.writing",
 		Usage: "Activates progressive writing of state diffs to database as new block are synced",
 	}
+	StateDiffWorkersFlag = cli.UintFlag{
+		Name:  "statediff.workers",
+		Usage: "Number of concurrent workers to use during statediff processing (0 = 1)",
+	}
 )
 
 // MakeDataDir retrieves the currently requested data directory, terminating
@@ -1744,9 +1748,8 @@ func RegisterGraphQLService(stack *node.Node, backend ethapi.Backend, cfg node.C
 }
 
 // RegisterStateDiffService configures and registers a service to stream state diff data over RPC
-// dbParams are: Postgres connection URI, Node ID, client name
-func RegisterStateDiffService(stack *node.Node, ethServ *eth.Ethereum, dbParams *statediff.DBParams, startWriteLoop bool) {
-	if err := statediff.New(stack, ethServ, dbParams, startWriteLoop); err != nil {
+func RegisterStateDiffService(stack *node.Node, ethServ *eth.Ethereum, params statediff.ServiceParams) {
+	if err := statediff.New(stack, ethServ, params); err != nil {
 		Fatalf("Failed to register the Statediff service: %v", err)
 	}
 }

--- a/statediff/indexer/metrics.go
+++ b/statediff/indexer/metrics.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	indexerNamespace = "indexer"
+	namespace = "statediff"
 )
 
 // Build a fully qualified metric name
@@ -16,9 +16,9 @@ func metricName(subsystem, name string) string {
 	if name == "" {
 		return ""
 	}
-	parts := []string{indexerNamespace, name}
+	parts := []string{namespace, name}
 	if subsystem != "" {
-		parts = []string{indexerNamespace, subsystem, name}
+		parts = []string{namespace, subsystem, name}
 	}
 	// Prometheus uses _ but geth metrics uses / and replaces
 	return strings.Join(parts, "/")
@@ -57,7 +57,7 @@ func RegisterIndexerMetrics(reg metrics.Registry) indexerMetricsHandles {
 		tTxAndRecProcessing:       metrics.NewTimer(),
 		tStateStoreCodeProcessing: metrics.NewTimer(),
 	}
-	subsys := "" // todo
+	subsys := "indexer"
 	reg.Register(metricName(subsys, "blocks"), ctx.blocks)
 	reg.Register(metricName(subsys, "transactions"), ctx.transactions)
 	reg.Register(metricName(subsys, "receipts"), ctx.receipts)

--- a/statediff/metrics.go
+++ b/statediff/metrics.go
@@ -44,7 +44,7 @@ func RegisterStatediffMetrics(reg metrics.Registry) statediffMetricsHandles {
 		serviceLoopChannelLen: metrics.NewGauge(),
 		writeLoopChannelLen:   metrics.NewGauge(),
 	}
-	subsys := "" // todo
+	subsys := "service"
 	reg.Register(metricName(subsys, "last_sync_height"), ctx.lastSyncHeight)
 	reg.Register(metricName(subsys, "last_event_height"), ctx.lastEventHeight)
 	reg.Register(metricName(subsys, "last_statediff_height"), ctx.lastStatediffHeight)

--- a/statediff/metrics.go
+++ b/statediff/metrics.go
@@ -1,0 +1,54 @@
+package statediff
+
+import (
+	"strings"
+
+	"github.com/ethereum/go-ethereum/metrics"
+)
+
+const (
+	namespace = "statediff"
+)
+
+// Build a fully qualified metric name
+func metricName(subsystem, name string) string {
+	if name == "" {
+		return ""
+	}
+	parts := []string{namespace, name}
+	if subsystem != "" {
+		parts = []string{namespace, subsystem, name}
+	}
+	// Prometheus uses _ but geth metrics uses / and replaces
+	return strings.Join(parts, "/")
+}
+
+type statediffMetricsHandles struct {
+	// Height of latest synced by core.BlockChain
+	// FIXME
+	lastSyncHeight metrics.Gauge
+	// Height of the latest block received from chainEvent channel
+	lastEventHeight metrics.Gauge
+	// Height of latest state diff
+	lastStatediffHeight metrics.Gauge
+	// Current length of chainEvent channels
+	serviceLoopChannelLen metrics.Gauge
+	writeLoopChannelLen   metrics.Gauge
+}
+
+func RegisterStatediffMetrics(reg metrics.Registry) statediffMetricsHandles {
+	ctx := statediffMetricsHandles{
+		lastSyncHeight:        metrics.NewGauge(),
+		lastEventHeight:       metrics.NewGauge(),
+		lastStatediffHeight:   metrics.NewGauge(),
+		serviceLoopChannelLen: metrics.NewGauge(),
+		writeLoopChannelLen:   metrics.NewGauge(),
+	}
+	subsys := "" // todo
+	reg.Register(metricName(subsys, "last_sync_height"), ctx.lastSyncHeight)
+	reg.Register(metricName(subsys, "last_event_height"), ctx.lastEventHeight)
+	reg.Register(metricName(subsys, "last_statediff_height"), ctx.lastStatediffHeight)
+	reg.Register(metricName(subsys, "service_loop_channel_len"), ctx.serviceLoopChannelLen)
+	reg.Register(metricName(subsys, "write_loop_channel_len"), ctx.writeLoopChannelLen)
+	return ctx
+}

--- a/statediff/service.go
+++ b/statediff/service.go
@@ -276,11 +276,11 @@ func (sds *Service) writeLoopWorker(params workerParams) {
 			// TODO: how to handle with concurrent workers
 			statediffMetrics.lastStatediffHeight.Update(int64(currentBlock.Number().Uint64()))
 		case err := <-params.errCh:
-			log.Warn("Error from chain event subscription", "error", err)
+			log.Warn("Error from chain event subscription", "error", err, "worker", params.id)
 			sds.close()
 			return
 		case <-sds.QuitChan:
-			log.Info("Quitting the statediff writing process")
+			log.Info("Quitting the statediff writing process", "worker", params.id)
 			sds.close()
 			return
 		}
@@ -480,11 +480,8 @@ func (sds *Service) Unsubscribe(id rpc.ID) error {
 func (sds *Service) Start() error {
 	log.Info("Starting statediff service")
 
-	{
-		// TODO: also use worker pool here?
-		chainEventCh := make(chan core.ChainEvent, chainEventChanSize)
-		go sds.Loop(chainEventCh)
-	}
+	chainEventCh := make(chan core.ChainEvent, chainEventChanSize)
+	go sds.Loop(chainEventCh)
 
 	if sds.enableWriteLoop {
 		log.Info("Starting statediff DB write loop", "params", writeLoopParams)

--- a/statediff/service.go
+++ b/statediff/service.go
@@ -22,7 +22,6 @@ import (
 	"strconv"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"

--- a/statediff/service.go
+++ b/statediff/service.go
@@ -200,8 +200,9 @@ func (sds *Service) APIs() []rpc.API {
 	}
 }
 
-// Return the parent block of currentBlock, using the cached block if available
-func (lbc *blockCache) replace(currentBlock *types.Block, bc blockChain) *types.Block {
+// Return the parent block of currentBlock, using the cached block if available;
+// and cache the passed block
+func (lbc *blockCache) getParentBlock(currentBlock *types.Block, bc blockChain) *types.Block {
 	lbc.Lock()
 	parentHash := currentBlock.ParentHash()
 	var parentBlock *types.Block
@@ -248,7 +249,7 @@ func (sds *Service) writeLoopWorker(params workerParams) {
 			log.Debug("WriteLoop(): chain event received", "event", chainEvent)
 			currentBlock := chainEvent.Block
 			statediffMetrics.lastEventHeight.Update(int64(currentBlock.Number().Uint64()))
-			parentBlock := sds.BlockCache.replace(currentBlock, sds.BlockChain)
+			parentBlock := sds.BlockCache.getParentBlock(currentBlock, sds.BlockChain)
 			if parentBlock == nil {
 				log.Error("Parent block is nil, skipping this block", "block height", currentBlock.Number())
 				continue
@@ -290,7 +291,7 @@ func (sds *Service) Loop(chainEventCh chan core.ChainEvent) {
 				continue
 			}
 			currentBlock := chainEvent.Block
-			parentBlock := sds.BlockCache.replace(currentBlock, sds.BlockChain)
+			parentBlock := sds.BlockCache.getParentBlock(currentBlock, sds.BlockChain)
 			if parentBlock == nil {
 				log.Error("Parent block is nil, skipping this block", "block height", currentBlock.Number())
 				continue

--- a/statediff/service_test.go
+++ b/statediff/service_test.go
@@ -94,6 +94,7 @@ func testErrorInChainEventLoop(t *testing.T) {
 		QuitChan:          serviceQuit,
 		Subscriptions:     make(map[common.Hash]map[rpc.ID]statediff.Subscription),
 		SubscriptionTypes: make(map[common.Hash]statediff.Params),
+		BlockCache:        statediff.NewBlockCache(1),
 	}
 	payloadChan := make(chan statediff.Payload, 2)
 	quitChan := make(chan bool)
@@ -177,6 +178,7 @@ func testErrorInBlockLoop(t *testing.T) {
 		QuitChan:          make(chan bool),
 		Subscriptions:     make(map[common.Hash]map[rpc.ID]statediff.Subscription),
 		SubscriptionTypes: make(map[common.Hash]statediff.Params),
+		BlockCache:        statediff.NewBlockCache(1),
 	}
 	payloadChan := make(chan statediff.Payload)
 	quitChan := make(chan bool)
@@ -256,6 +258,7 @@ func testErrorInStateDiffAt(t *testing.T) {
 		QuitChan:          make(chan bool),
 		Subscriptions:     make(map[common.Hash]map[rpc.ID]statediff.Subscription),
 		SubscriptionTypes: make(map[common.Hash]statediff.Params),
+		BlockCache:        statediff.NewBlockCache(1),
 	}
 	stateDiffPayload, err := service.StateDiffAt(testBlock1.NumberU64(), defaultParams)
 	if err != nil {


### PR DESCRIPTION
Changes statediff service to spawn a pool of workers each running an independent `WriteLoop`.

* Number of workers is configured with a new `statediff.workers` CLI flag.
* Expands the lastBlock cache to use a map of hashes to blocks, with a max size also limited to the number of workers.
* Geth uses an internal cache for receipts and other data; this causes a data race to be detected inside `receipts.DeriveFields()` when used during indexing, though I didn't debug this deeply enough to find out why the same receipts data would ever be touched by goroutines which should only be working on separate blocks.
* There is still a data race issue in the Trie data access, <strike>probably due to the `state.Database` hitting its cache limit.</strike>(cache miss shouldn't cause this)

Resolves https://github.com/vulcanize/go-ethereum/issues/41