### PR TITLE
add poststate and status to receipt ipld indexes

### DIFF
--- a/statediff/indexer/indexer_test.go
+++ b/statediff/indexer/indexer_test.go
@@ -183,10 +183,31 @@ func TestPublishAndIndexer(t *testing.T) {
 			switch c {
 			case mocks.Rct1CID.String():
 				shared.ExpectEqual(t, data, mocks.MockReceipts.GetRlp(0))
+				var postStatus uint64
+				pgStr = `SELECT post_status FROM eth.receipt_cids WHERE cid = $1`
+				err = db.Get(&postStatus, pgStr, c)
+				if err != nil {
+					t.Fatal(err)
+				}
+				shared.ExpectEqual(t, postStatus, mocks.ExpectedPostStatus)
 			case mocks.Rct2CID.String():
 				shared.ExpectEqual(t, data, mocks.MockReceipts.GetRlp(1))
+				var postState string
+				pgStr = `SELECT post_state FROM eth.receipt_cids WHERE cid = $1`
+				err = db.Get(&postState, pgStr, c)
+				if err != nil {
+					t.Fatal(err)
+				}
+				shared.ExpectEqual(t, postState, mocks.ExpectedPostState1)
 			case mocks.Rct3CID.String():
 				shared.ExpectEqual(t, data, mocks.MockReceipts.GetRlp(2))
+				var postState string
+				pgStr = `SELECT post_state FROM eth.receipt_cids WHERE cid = $1`
+				err = db.Get(&postState, pgStr, c)
+				if err != nil {
+					t.Fatal(err)
+				}
+				shared.ExpectEqual(t, postState, mocks.ExpectedPostState2)
 			}
 		}
 	})

--- a/statediff/indexer/mocks/test_data.go
+++ b/statediff/indexer/mocks/test_data.go
@@ -51,20 +51,23 @@ var (
 		Difficulty:  big.NewInt(5000000),
 		Extra:       []byte{},
 	}
-	MockTransactions, MockReceipts, SenderAddr = createTransactionsAndReceipts()
-	ReceiptsRlp, _                             = rlp.EncodeToBytes(MockReceipts)
-	MockBlock                                  = types.NewBlock(&MockHeader, MockTransactions, nil, MockReceipts, new(trie.Trie))
-	MockHeaderRlp, _                           = rlp.EncodeToBytes(MockBlock.Header())
-	Address                                    = common.HexToAddress("0xaE9BEa628c4Ce503DcFD7E305CaB4e29E7476592")
-	AnotherAddress                             = common.HexToAddress("0xaE9BEa628c4Ce503DcFD7E305CaB4e29E7476593")
-	ContractAddress                            = crypto.CreateAddress(SenderAddr, MockTransactions[2].Nonce())
-	ContractHash                               = crypto.Keccak256Hash(ContractAddress.Bytes()).String()
-	MockContractByteCode                       = []byte{0, 1, 2, 3, 4, 5}
-	mockTopic11                                = common.HexToHash("0x04")
-	mockTopic12                                = common.HexToHash("0x06")
-	mockTopic21                                = common.HexToHash("0x05")
-	mockTopic22                                = common.HexToHash("0x07")
-	MockLog1                                   = &types.Log{
+	MockTransactions, MockReceipts, SenderAddr        = createTransactionsAndReceipts()
+	ReceiptsRlp, _                                    = rlp.EncodeToBytes(MockReceipts)
+	MockBlock                                         = types.NewBlock(&MockHeader, MockTransactions, nil, MockReceipts, new(trie.Trie))
+	MockHeaderRlp, _                                  = rlp.EncodeToBytes(MockBlock.Header())
+	Address                                           = common.HexToAddress("0xaE9BEa628c4Ce503DcFD7E305CaB4e29E7476592")
+	AnotherAddress                                    = common.HexToAddress("0xaE9BEa628c4Ce503DcFD7E305CaB4e29E7476593")
+	ContractAddress                                   = crypto.CreateAddress(SenderAddr, MockTransactions[2].Nonce())
+	ContractHash                                      = crypto.Keccak256Hash(ContractAddress.Bytes()).String()
+	MockContractByteCode                              = []byte{0, 1, 2, 3, 4, 5}
+	mockTopic11                                       = common.HexToHash("0x04")
+	mockTopic12                                       = common.HexToHash("0x06")
+	mockTopic21                                       = common.HexToHash("0x05")
+	mockTopic22                                       = common.HexToHash("0x07")
+	ExpectedPostStatus                         uint64 = 1
+	ExpectedPostState1                                = common.Bytes2Hex(common.HexToHash("0x1").Bytes())
+	ExpectedPostState2                                = common.Bytes2Hex(common.HexToHash("0x2").Bytes())
+	MockLog1                                          = &types.Log{
 		Address: Address,
 		Topics:  []common.Hash{mockTopic11, mockTopic12},
 		Data:    []byte{},
@@ -181,7 +184,7 @@ func createTransactionsAndReceipts() (types.Transactions, types.Receipts, common
 		log.Crit(err.Error())
 	}
 	// make receipts
-	mockReceipt1 := types.NewReceipt(common.HexToHash("0x0").Bytes(), false, 50)
+	mockReceipt1 := types.NewReceipt(nil, false, 50)
 	mockReceipt1.Logs = []*types.Log{MockLog1}
 	mockReceipt1.TxHash = signedTrx1.Hash()
 	mockReceipt2 := types.NewReceipt(common.HexToHash("0x1").Bytes(), false, 100)

--- a/statediff/indexer/models/models.go
+++ b/statediff/indexer/models/models.go
@@ -51,16 +51,15 @@ type UncleModel struct {
 
 // TxModel is the db model for eth.transaction_cids
 type TxModel struct {
-	ID         int64  `db:"id"`
-	HeaderID   int64  `db:"header_id"`
-	Index      int64  `db:"index"`
-	TxHash     string `db:"tx_hash"`
-	CID        string `db:"cid"`
-	MhKey      string `db:"mh_key"`
-	Dst        string `db:"dst"`
-	Src        string `db:"src"`
-	Data       []byte `db:"tx_data"`
-	Deployment bool   `db:"deployment"`
+	ID       int64  `db:"id"`
+	HeaderID int64  `db:"header_id"`
+	Index    int64  `db:"index"`
+	TxHash   string `db:"tx_hash"`
+	CID      string `db:"cid"`
+	MhKey    string `db:"mh_key"`
+	Dst      string `db:"dst"`
+	Src      string `db:"src"`
+	Data     []byte `db:"tx_data"`
 }
 
 // ReceiptModel is the db model for eth.receipt_cids
@@ -69,6 +68,8 @@ type ReceiptModel struct {
 	TxID         int64          `db:"tx_id"`
 	CID          string         `db:"cid"`
 	MhKey        string         `db:"mh_key"`
+	PostStatus   uint64         `db:"post_status"`
+	PostState    string         `db:"post_state"`
 	Contract     string         `db:"contract"`
 	ContractHash string         `db:"contract_hash"`
 	LogContracts pq.StringArray `db:"log_contracts"`

--- a/statediff/indexer/writer.go
+++ b/statediff/indexer/writer.go
@@ -96,9 +96,9 @@ func (in *PostgresCIDWriter) upsertTransactionCID(tx *sqlx.Tx, transaction model
 }
 
 func (in *PostgresCIDWriter) upsertReceiptCID(tx *sqlx.Tx, rct models.ReceiptModel, txID int64) error {
-	_, err := tx.Exec(`INSERT INTO eth.receipt_cids (tx_id, cid, contract, contract_hash, topic0s, topic1s, topic2s, topic3s, log_contracts, mh_key) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-							  ON CONFLICT (tx_id) DO UPDATE SET (cid, contract, contract_hash, topic0s, topic1s, topic2s, topic3s, log_contracts, mh_key) = ($2, $3, $4, $5, $6, $7, $8, $9, $10)`,
-		txID, rct.CID, rct.Contract, rct.ContractHash, rct.Topic0s, rct.Topic1s, rct.Topic2s, rct.Topic3s, rct.LogContracts, rct.MhKey)
+	_, err := tx.Exec(`INSERT INTO eth.receipt_cids (tx_id, cid, contract, contract_hash, topic0s, topic1s, topic2s, topic3s, log_contracts, mh_key, post_state, post_status) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+							  ON CONFLICT (tx_id) DO UPDATE SET (cid, contract, contract_hash, topic0s, topic1s, topic2s, topic3s, log_contracts, mh_key, post_state, post_status) = ($2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
+		txID, rct.CID, rct.Contract, rct.ContractHash, rct.Topic0s, rct.Topic1s, rct.Topic2s, rct.Topic3s, rct.LogContracts, rct.MhKey, rct.PostState, rct.PostStatus)
 	if err == nil {
 		indexerMetrics.receipts.Inc(1)
 	}


### PR DESCRIPTION
* Add poststate and status to receipt ipld indexes
* Update unit tests
* Remove vestigial tx `isDeployment` code

Satisfies #50 

Note: after EIP 98 only status is stored in receipt, before EIP 98 the intermediate state root is packed into those bytes https://github.com/ethereum/EIPs/issues/98