### PR TITLE
update github actions and version meta after v1.10.3 rebase

### DIFF
--- a/.github/workflows/on-master.yaml
+++ b/.github/workflows/on-master.yaml
@@ -3,6 +3,7 @@ name: Docker Build and publish to Github
 on:
   push:
     branches:
+      - v1.10.3-statediff
       - v1.10.2-statediff
       - v1.10.1-statediff
       - v1.9.25-statediff

--- a/params/version.go
+++ b/params/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	VersionMajor = 1        // Major version component of the current release
-	VersionMinor = 10       // Minor version component of the current release
-	VersionPatch = 3        // Patch version component of the current release
-	VersionMeta  = "stable" // Version metadata to append to the version string
+	VersionMajor = 1                  // Major version component of the current release
+	VersionMinor = 10                 // Minor version component of the current release
+	VersionPatch = 3                  // Patch version component of the current release
+	VersionMeta  = "statediff-0.0.21" // Version metadata to append to the version string
 )
 
 // Version holds the textual version string.


### PR DESCRIPTION
On v1.10.3-statediff we have squashed and rebased our statediffing code ontop of the new root branch tagged release (v1.10.3). This simply bumps the version meta and updates GitHub actions to build off this new root statediff branch.