### PR TITLE
block and uncle reward in PoA network = 0 

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ const (
 	VersionMajor = 1                  // Major version component of the current release
 	VersionMinor = 10                 // Minor version component of the current release
 	VersionPatch = 3                  // Patch version component of the current release
-	VersionMeta  = "statediff-0.0.23" // Version metadata to append to the version string
+	VersionMeta  = "statediff-0.0.24" // Version metadata to append to the version string
 )
 
 // Version holds the textual version string.


### PR DESCRIPTION
The same as https://github.com/vulcanize/go-ethereum/pull/86 but based on top of `v1.10.3-statediff` branch