### PR TITLE
Merge v1.10.12-statediff-0.0.27 to v1.10.12-statediff 

### DIFF
--- a/.github/workflows/on-master.yaml
+++ b/.github/workflows/on-master.yaml
@@ -3,7 +3,7 @@ name: Docker Build and publish to Github
 on:
   push:
     branches:
-      - v1.10.11-statediff
+      - v1.10.12-statediff
       - v1.10.11-statediff
       - v1.10.10-statediff
       - v1.10.9-statediff

--- a/.github/workflows/on-master.yaml
+++ b/.github/workflows/on-master.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - v1.10.11-statediff
+      - v1.10.11-statediff
       - v1.10.10-statediff
       - v1.10.9-statediff
       - v1.10.8-statediff


### PR DESCRIPTION
Remove cross-compile build from Makefile
* https://github.com/ethereum/go-ethereum/issues/23784