### PR TITLE
Log processing bug fix

### DIFF
--- a/statediff/indexer/ipld/eth_log_trie.go
+++ b/statediff/indexer/ipld/eth_log_trie.go
@@ -114,14 +114,8 @@ func (rt *logTrie) getNodeFromDB(key []byte) (*EthLogTrie, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	c, err := RawdataToCid(MEthLogTrie, rawdata, multihash.KECCAK_256)
-	if err != nil {
-		return nil, err
-	}
-
 	tn := &TrieNode{
-		cid:     c,
+		cid:     keccak256ToCid(MEthLogTrie, key),
 		rawdata: rawdata,
 	}
 	return &EthLogTrie{TrieNode: tn}, nil
@@ -134,7 +128,6 @@ func (rt *logTrie) getLeafNodes() ([]*EthLogTrie, []*nodeKey, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-
 	out := make([]*EthLogTrie, 0, len(keys))
 	for _, k := range keys {
 		n, err := rt.getNodeFromDB(k.dbKey)

--- a/statediff/indexer/ipld/eth_receipt_trie.go
+++ b/statediff/indexer/ipld/eth_receipt_trie.go
@@ -166,14 +166,8 @@ func (rt *rctTrie) getNodeFromDB(key []byte) (*EthRctTrie, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	cid, err := RawdataToCid(MEthTxReceiptTrie, rawdata, multihash.KECCAK_256)
-	if err != nil {
-		return nil, err
-	}
-
 	tn := &TrieNode{
-		cid:     cid,
+		cid:     keccak256ToCid(MEthStateTrie, key),
 		rawdata: rawdata,
 	}
 

--- a/statediff/indexer/ipld/eth_tx_trie.go
+++ b/statediff/indexer/ipld/eth_tx_trie.go
@@ -135,12 +135,8 @@ func (tt *txTrie) getNodes() ([]*EthTxTrie, error) {
 		if err != nil {
 			return nil, err
 		}
-		c, err := RawdataToCid(MEthTxTrie, rawdata, multihash.KECCAK_256)
-		if err != nil {
-			return nil, err
-		}
 		tn := &TrieNode{
-			cid:     c,
+			cid:     keccak256ToCid(MEthTxTrie, k),
 			rawdata: rawdata,
 		}
 		out = append(out, &EthTxTrie{TrieNode: tn})


### PR DESCRIPTION
For #161  see https://github.com/vulcanize/go-ethereum/issues/161#issuecomment-982860300

This fixes it by substituting dangling "value node" log IPLD references in the place of a proper leaf node IPLD reference.

