### PR TITLE
Fix CI tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,11 @@ ios:
 
 .PHONY: statedifftest
 statedifftest: | $(GOOSE)
-	MODE=statediff go test ./statediff/... -v
+	MODE=statediff go test -p 1 ./statediff/... -v
+
+.PHONY: statediff_filewriting_test
+statediff_filetest: | $(GOOSE)
+	MODE=statediff STATEDIFF_DB=file go test -p 1 ./statediff/... -v
 
 test: all
 	$(GORUN) build/ci.go test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.2'
 services:
   ipld-eth-db:
     restart: always
-    image: vulcanize/ipld-eth-db:v0.2.0
+    image: vulcanize/ipld-eth-db:v0.3.1
     environment:
       POSTGRES_USER: "vdbm"
       POSTGRES_DB: "vulcanize_public"

--- a/params/version.go
+++ b/params/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	VersionMajor = 1                  // Major version component of the current release
-	VersionMinor = 10                 // Minor version component of the current release
-	VersionPatch = 11                 // Patch version component of the current release
-	VersionMeta  = "statediff-0.0.27" // Version metadata to append to the version string
+	VersionMajor = 1                 // Major version component of the current release
+	VersionMinor = 10                // Minor version component of the current release
+	VersionPatch = 11                // Patch version component of the current release
+	VersionMeta  = "statediff-0.1.0" // Version metadata to append to the version string
 )
 
 // Version holds the textual version string.

--- a/statediff/indexer/database/file/mainnet_tests/indexer_test.go
+++ b/statediff/indexer/database/file/mainnet_tests/indexer_test.go
@@ -46,6 +46,10 @@ func init() {
 		fmt.Println("Skipping statediff test")
 		os.Exit(0)
 	}
+	if os.Getenv("STATEDIFF_DB") != "file" {
+		fmt.Println("Skipping statediff .sql file writing mode test")
+		os.Exit(0)
+	}
 }
 
 func TestPushBlockAndState(t *testing.T) {


### PR DESCRIPTION
* fixes #153
* can consider #146 done as well
* use db v0.3.0 in compose
* bump statediff meta version
* prevent parallel execution of tests from different pkgs, this was causing a deadlock