### PR TITLE
Add a flag to start processing statediff if we are caught up to the head of the chain

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -258,8 +258,9 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 			Context:         context.Background(),
 			EnableWriteLoop: ctx.GlobalBool(utils.StateDiffWritingFlag.Name),
 			NumWorkers:      ctx.GlobalUint(utils.StateDiffWorkersFlag.Name),
+			WaitForSync:     ctx.GlobalBool(utils.StateDiffWaitForSync.Name),
 		}
-		utils.RegisterStateDiffService(stack, eth, &cfg.Eth, p)
+		utils.RegisterStateDiffService(stack, eth, &cfg.Eth, p, backend)
 	}
 
 	// Configure GraphQL if requested

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -176,6 +176,7 @@ var (
 		utils.StateDiffWritingFlag,
 		utils.StateDiffWorkersFlag,
 		utils.StateDiffFilePath,
+		utils.StateDiffWaitForSync,
 		configFileFlag,
 	}
 

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -246,6 +246,7 @@ var AppHelpFlagGroups = []flags.FlagGroup{
 			utils.StateDiffWritingFlag,
 			utils.StateDiffWorkersFlag,
 			utils.StateDiffFilePath,
+			utils.StateDiffWaitForSync,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -881,6 +881,10 @@ var (
 		Usage: "Number of concurrent workers to use during statediff processing (default 1)",
 		Value: 1,
 	}
+	StateDiffWaitForSync = cli.BoolFlag{
+		Name:  "statediff.waitforsync",
+		Usage: "Should the statediff service wait for geth to catch up to the head of the chain?",
+	}
 )
 
 // MakeDataDir retrieves the currently requested data directory, terminating
@@ -1865,8 +1869,8 @@ func RegisterGraphQLService(stack *node.Node, backend ethapi.Backend, cfg node.C
 }
 
 // RegisterStateDiffService configures and registers a service to stream state diff data over RPC
-func RegisterStateDiffService(stack *node.Node, ethServ *eth.Ethereum, cfg *ethconfig.Config, params statediff.Config) {
-	if err := statediff.New(stack, ethServ, cfg, params); err != nil {
+func RegisterStateDiffService(stack *node.Node, ethServ *eth.Ethereum, cfg *ethconfig.Config, params statediff.Config, backend ethapi.Backend) {
+	if err := statediff.New(stack, ethServ, cfg, params, backend); err != nil {
 		Fatalf("Failed to register the Statediff service: %v", err)
 	}
 }

--- a/statediff/README.md
+++ b/statediff/README.md
@@ -81,24 +81,43 @@ This state diffing service runs as an auxiliary service concurrent to the regula
 This service introduces a CLI flag namespace `statediff`
 
 `--statediff` flag is used to turn on the service
+
 `--statediff.writing` is used to tell the service to write state diff objects it produces from synced ChainEvents directly to a configured Postgres database
+
 `--statediff.workers` is used to set the number of concurrent workers to process state diff objects and write them into the database
+
 `--statediff.db.type` is the type of database we write out to (current options: postgres, dump, file)
+
 `--statediff.dump.dst` is the destination to write to when operating in database dump mode (stdout, stderr, discard)
+
 `--statediff.db.driver` is the specific driver to use for the database (current options for postgres: pgx and sqlx)
+
 `--statediff.db.host` is the hostname/ip to dial to connect to the database
+
 `--statediff.db.port` is the port to dial to connect to the database
+
 `--statediff.db.name` is the name of the database to connect to
+
 `--statediff.db.user` is the user to connect to the database as
+
 `--statediff.db.password` is the password to use to connect to the database
+
 `--statediff.db.conntimeout` is the connection timeout (in seconds)
+
 `--statediff.db.maxconns` is the maximum number of database connections
+
 `--statediff.db.minconns` is the minimum number of database connections
+
 `--statediff.db.maxidleconns` is the maximum number of idle connections
+
 `--statediff.db.maxconnidletime` is the maximum lifetime for an idle connection (in seconds)
+
 `--statediff.db.maxconnlifetime` is the maximum lifetime for a connection (in seconds)
+
 `--statediff.db.nodeid` is the node id to use in the Postgres database
+
 `--statediff.db.clientname` is the client name to use in the Postgres database
+
 `--statediff.file.path` full path (including filename) to write statediff data out to when operating in file mode
 
 The service can only operate in full sync mode (`--syncmode=full`), but only the historical RPC endpoints require an archive node (`--gcmode=archive`)

--- a/statediff/config.go
+++ b/statediff/config.go
@@ -35,6 +35,8 @@ type Config struct {
 	EnableWriteLoop bool
 	// Size of the worker pool
 	NumWorkers uint
+	// Should the statediff service wait until geth has synced to the head of the blockchain?
+	WaitForSync bool
 	// Context
 	Context context.Context
 }

--- a/statediff/service.go
+++ b/statediff/service.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ethereum/go-ethereum/eth"
 	"github.com/ethereum/go-ethereum/eth/ethconfig"
 	"github.com/ethereum/go-ethereum/event"
+	"github.com/ethereum/go-ethereum/internal/ethapi"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/node"
@@ -118,11 +119,15 @@ type Service struct {
 	SubscriptionTypes map[common.Hash]Params
 	// Cache the last block so that we can avoid having to lookup the next block's parent
 	BlockCache BlockCache
+	// The publicBackendAPI which provides useful information about the current state
+	BackendAPI ethapi.Backend
+	// Should the statediff service wait for geth to sync to head?
+	WaitforSync bool
 	// Whether or not we have any subscribers; only if we do, do we processes state diffs
 	subscribers int32
 	// Interface for publishing statediffs as PG-IPLD objects
 	indexer interfaces.StateDiffIndexer
-	// Whether to enable writing state diffs directly to track blochain head
+	// Whether to enable writing state diffs directly to track blockchain head.
 	enableWriteLoop bool
 	// Size of the worker pool
 	numWorkers uint
@@ -146,7 +151,7 @@ func NewBlockCache(max uint) BlockCache {
 
 // New creates a new statediff.Service
 // func New(stack *node.Node, ethServ *eth.Ethereum, dbParams *DBParams, enableWriteLoop bool) error {
-func New(stack *node.Node, ethServ *eth.Ethereum, cfg *ethconfig.Config, params Config) error {
+func New(stack *node.Node, ethServ *eth.Ethereum, cfg *ethconfig.Config, params Config, backend ethapi.Backend) error {
 	blockChain := ethServ.BlockChain()
 	var indexer interfaces.StateDiffIndexer
 	quitCh := make(chan bool)
@@ -177,6 +182,8 @@ func New(stack *node.Node, ethServ *eth.Ethereum, cfg *ethconfig.Config, params 
 		Subscriptions:     make(map[common.Hash]map[rpc.ID]Subscription),
 		SubscriptionTypes: make(map[common.Hash]Params),
 		BlockCache:        NewBlockCache(workers),
+		BackendAPI:        backend,
+		WaitforSync:       params.WaitForSync,
 		indexer:           indexer,
 		enableWriteLoop:   params.EnableWriteLoop,
 		numWorkers:        workers,
@@ -528,10 +535,48 @@ func (sds *Service) Unsubscribe(id rpc.ID) error {
 	return nil
 }
 
+// This function will check the status of geth syncing.
+// It will return false if geth has finished syncing.
+// It will return a non false value if geth is not done syncing.
+func (sds *Service) GetSyncStatus(pubEthAPI *ethapi.PublicEthereumAPI) (interface{}, error) {
+	syncStatus, err := pubEthAPI.Syncing()
+	if err != nil {
+		return nil, err
+	}
+	return syncStatus, err
+}
+
+// This function calls GetSyncStatus to check if we have caught up to head.
+// It will keep looking and checking if we have caught up to head.
+// It will only complete if we catch up to head, otherwise it will keep looping forever.
+func (sds *Service) WaitForSync() error {
+	log.Info("We are going to wait for geth to sync to head!")
+
+	// Has the geth node synced to head?
+	Synced := false
+	pubEthAPI := ethapi.NewPublicEthereumAPI(sds.BackendAPI)
+	for !Synced {
+		syncStatus, err := sds.GetSyncStatus(pubEthAPI)
+		if err != nil {
+			return err
+		}
+		if syncStatus == false {
+			log.Info("Geth has caught up to the head of the chain")
+			Synced = true
+		}
+	}
+	return nil
+}
+
 // Start is used to begin the service
 func (sds *Service) Start() error {
 	log.Info("Starting statediff service")
 
+	if sds.WaitforSync {
+		log.Info("Statediff service will wait until geth has caught up to the head of the chain.")
+		sds.WaitForSync()
+		log.Info("Continuing with startdiff start process")
+	}
 	chainEventCh := make(chan core.ChainEvent, chainEventChanSize)
 	go sds.Loop(chainEventCh)
 

--- a/statediff/service_test.go
+++ b/statediff/service_test.go
@@ -23,18 +23,18 @@ import (
 	"reflect"
 	"sync"
 	"testing"
-
-	types2 "github.com/ethereum/go-ethereum/statediff/types"
-
-	"github.com/ethereum/go-ethereum/trie"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/internal/ethapi"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
 	statediff "github.com/ethereum/go-ethereum/statediff"
 	"github.com/ethereum/go-ethereum/statediff/test_helpers/mocks"
+	types2 "github.com/ethereum/go-ethereum/statediff/types"
+	"github.com/ethereum/go-ethereum/trie"
 )
 
 func TestServiceLoop(t *testing.T) {
@@ -290,4 +290,152 @@ func testErrorInStateDiffAt(t *testing.T) {
 		t.Error("Test failure:", t.Name())
 		t.Logf("Actual state diff payload does not equal expected.\nactual:%+v\nexpected: %+v", expectedStateDiffPayload, stateDiffPayload)
 	}
+}
+
+func TestWaitForSync(t *testing.T) {
+	testWaitForSync(t)
+	testGetSyncStatus(t)
+}
+
+// This function will create a backend and service object which includes a generic Backend
+func createServiceWithMockBackend(curBlock uint64, highestBlock uint64) (*mocks.Backend, *statediff.Service) {
+	builder := mocks.Builder{}
+	blockChain := mocks.BlockChain{}
+	backend := mocks.Backend{
+		StartingBlock:       1,
+		CurrBlock:           curBlock,
+		HighestBlock:        highestBlock,
+		SyncedAccounts:      5,
+		SyncedAccountBytes:  5,
+		SyncedBytecodes:     5,
+		SyncedBytecodeBytes: 5,
+		SyncedStorage:       5,
+		SyncedStorageBytes:  5,
+		HealedTrienodes:     5,
+		HealedTrienodeBytes: 5,
+		HealedBytecodes:     5,
+		HealedBytecodeBytes: 5,
+		HealingTrienodes:    5,
+		HealingBytecode:     5,
+	}
+
+	service := &statediff.Service{
+		Mutex:             sync.Mutex{},
+		Builder:           &builder,
+		BlockChain:        &blockChain,
+		QuitChan:          make(chan bool),
+		Subscriptions:     make(map[common.Hash]map[rpc.ID]statediff.Subscription),
+		SubscriptionTypes: make(map[common.Hash]statediff.Params),
+		BlockCache:        statediff.NewBlockCache(1),
+		BackendAPI:        &backend,
+		WaitforSync:       true,
+	}
+	return &backend, service
+}
+
+// This function will test to make sure that the state diff waits
+// until the blockchain has caught up to head!
+func testWaitForSync(t *testing.T) {
+	t.Log("Starting Sync")
+	_, service := createServiceWithMockBackend(10, 10)
+	err := service.WaitForSync()
+	if err != nil {
+		t.Fatal("Sync Failed")
+	}
+	t.Log("Sync Complete")
+}
+
+// This test will run the WaitForSync() at the start of the execusion
+// It will then incrementally increase the currentBlock to match the highestBlock
+// At each interval it will run the GetSyncStatus to ensure that the return value is not false.
+// It will also check to make sure that the WaitForSync() function has not completed!
+func testGetSyncStatus(t *testing.T) {
+	t.Log("Starting Get Sync Status Test")
+	var highestBlock uint64 = 5
+	// Create a backend and a service
+	// the backend is lagging behind the sync.
+	backend, service := createServiceWithMockBackend(0, highestBlock)
+
+	checkSyncComplete := make(chan int, 1)
+
+	go func() {
+		// Start the sync function which will wait for the sync
+		// Once the sync is complete add a value to the checkSyncComplet channel
+		t.Log("Starting Sync")
+		err := service.WaitForSync()
+		if err != nil {
+			t.Error("Sync Failed")
+			checkSyncComplete <- 1
+		}
+		t.Log("We have finally synced!")
+		checkSyncComplete <- 0
+	}()
+
+	tables := []struct {
+		currentBlock uint64
+		highestBlock uint64
+	}{
+		{1, highestBlock},
+		{2, highestBlock},
+		{3, highestBlock},
+		{4, highestBlock},
+		{5, highestBlock},
+	}
+
+	time.Sleep(2 * time.Second)
+	for _, table := range tables {
+		// Iterate over each block
+		// Once the highest block reaches the current block the sync should complete
+
+		// Update the backend current block value
+		t.Log("Updating Current Block to: ", table.currentBlock)
+		backend.CurrBlock = table.currentBlock
+		pubEthAPI := ethapi.NewPublicEthereumAPI(service.BackendAPI)
+		syncStatus, err := service.GetSyncStatus(pubEthAPI)
+
+		if err != nil {
+			t.Fatal("Sync Failed")
+		}
+
+		time.Sleep(1 * time.Second)
+
+		// Make sure if syncStatus is false that WaitForSync has completed!
+		if syncStatus == false && len(checkSyncComplete) == 0 {
+			t.Error("Sync is complete but WaitForSync is not")
+		}
+
+		if syncStatus != false && len(checkSyncComplete) == 1 {
+			t.Error("Sync is not complete but WaitForSync is")
+		}
+
+		// Make sure sync hasn't completed and that the checkSyncComplete channel is empty
+		if syncStatus != false && len(checkSyncComplete) == 0 {
+			continue
+		}
+
+		// This code will only be run if the sync is complete and the WaitForSync function is complete
+		//t.Log("Backend: ", backend)
+		//t.Log("Sync Status: ", syncStatus)
+
+		// If syncstatus is complete, make sure that the blocks match
+		if syncStatus == false && table.currentBlock != table.highestBlock {
+			t.Errorf("syncStatus indicated sync was complete even when current block, %d, and highest block %d aren't equal",
+				table.currentBlock, table.highestBlock)
+		}
+
+		// Make sure that WaitForSync completed once the current block caught up to head!
+		if len(checkSyncComplete) == 1 {
+			checkSyncCompleteVal := <-checkSyncComplete
+			if checkSyncCompleteVal != 0 {
+				t.Errorf("syncStatus indicated sync was complete but the checkSyncComplete has a value of %d",
+					checkSyncCompleteVal)
+			} else {
+				t.Log("Test Passed!")
+			}
+
+		} else {
+			t.Error("checkSyncComplete is empty: ", len(checkSyncComplete))
+		}
+	}
+
 }

--- a/statediff/test_helpers/mocks/backend.go
+++ b/statediff/test_helpers/mocks/backend.go
@@ -39,7 +39,7 @@ import (
 // Builder is a mock state diff builder
 type Backend struct {
 	StartingBlock       uint64
-	CurrBlock        	uint64
+	CurrBlock           uint64
 	HighestBlock        uint64
 	SyncedAccounts      uint64
 	SyncedAccountBytes  uint64
@@ -251,4 +251,3 @@ func (backend *Backend) ChainConfig() *params.ChainConfig {
 func (backend *Backend) Engine() consensus.Engine {
 	panic("not implemented") // TODO: Implement
 }
-

--- a/statediff/test_helpers/mocks/backend.go
+++ b/statediff/test_helpers/mocks/backend.go
@@ -1,0 +1,254 @@
+// Copyright 2019 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package mocks
+
+import (
+	"context"
+	"math/big"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/bloombits"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+// Builder is a mock state diff builder
+type Backend struct {
+	StartingBlock       uint64
+	CurrBlock        	uint64
+	HighestBlock        uint64
+	SyncedAccounts      uint64
+	SyncedAccountBytes  uint64
+	SyncedBytecodes     uint64
+	SyncedBytecodeBytes uint64
+	SyncedStorage       uint64
+	SyncedStorageBytes  uint64
+	HealedTrienodes     uint64
+	HealedTrienodeBytes uint64
+	HealedBytecodes     uint64
+	HealedBytecodeBytes uint64
+	HealingTrienodes    uint64
+	HealingBytecode     uint64
+}
+
+// General Ethereum API
+func (backend *Backend) SyncProgress() ethereum.SyncProgress {
+	l := ethereum.SyncProgress{
+		StartingBlock:       backend.StartingBlock,
+		CurrentBlock:        backend.CurrBlock,
+		HighestBlock:        backend.HighestBlock,
+		SyncedAccounts:      backend.SyncedAccounts,
+		SyncedAccountBytes:  backend.SyncedAccountBytes,
+		SyncedBytecodes:     backend.SyncedBytecodes,
+		SyncedBytecodeBytes: backend.SyncedBytecodeBytes,
+		SyncedStorage:       backend.SyncedStorage,
+		SyncedStorageBytes:  backend.SyncedStorageBytes,
+		HealedTrienodes:     backend.HealedTrienodes,
+		HealedTrienodeBytes: backend.HealedTrienodeBytes,
+		HealedBytecodes:     backend.HealedBytecodes,
+		HealedBytecodeBytes: backend.HealedBytecodeBytes,
+		HealingTrienodes:    backend.HealingTrienodes,
+		HealingBytecode:     backend.HealingBytecode,
+	}
+	return l
+}
+
+func (backend *Backend) SuggestGasTipCap(ctx context.Context) (*big.Int, error) {
+	panic("not implemented") // TODO: Implement
+}
+
+func (backend *Backend) FeeHistory(ctx context.Context, blockCount int, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (*big.Int, [][]*big.Int, []*big.Int, []float64, error) {
+	panic("not implemented") // TODO: Implement
+}
+
+func (backend *Backend) ChainDb() ethdb.Database {
+	panic("not implemented") // TODO: Implement
+}
+
+func (backend *Backend) AccountManager() *accounts.Manager {
+	panic("not implemented") // TODO: Implement
+}
+
+func (backend *Backend) ExtRPCEnabled() bool {
+	panic("not implemented") // TODO: Implement
+}
+
+func (backend *Backend) RPCGasCap() uint64 {
+	panic("not implemented") // TODO: Implement
+}
+
+func (backend *Backend) RPCEVMTimeout() time.Duration {
+	panic("not implemented") // TODO: Implement
+}
+
+func (backend *Backend) RPCTxFeeCap() float64 {
+	panic("not implemented") // TODO: Implement
+}
+
+func (backend *Backend) UnprotectedAllowed() bool {
+	panic("not implemented") // TODO: Implement
+}
+
+// Blockchain API
+func (backend *Backend) SetHead(number uint64) {
+	panic("not implemented") // TODO: Implement
+}
+
+func (backend *Backend) HeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Header, error) {
+	panic("not implemented") // TODO: Implement
+}
+
+func (backend *Backend) HeaderByHash(ctx context.Context, hash common.Hash) (*types.Header, error) {
+	panic("not implemented") // TODO: Implement
+}
+
+func (backend *Backend) HeaderByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*types.Header, error) {
+	panic("not implemented") // TODO: Implement
+}
+
+func (backend *Backend) CurrentHeader() *types.Header {
+	panic("not implemented") // TODO: Implement
+}
+
+func (backend *Backend) CurrentBlock() *types.Block {
+	panic("not implemented") // TODO: Implement
+}
+
+func (backend *Backend) BlockByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Block, error) {
+	panic("not implemented") // TODO: Implement
+}
+
+func (backend *Backend) BlockByHash(ctx context.Context, hash common.Hash) (*types.Block, error) {
+	panic("not implemented") // TODO: Implement
+}
+
+func (backend *Backend) BlockByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*types.Block, error) {
+	panic("not implemented") // TODO: Implement
+}
+
+func (backend *Backend) StateAndHeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*state.StateDB, *types.Header, error) {
+	panic("not implemented") // TODO: Implement
+}
+
+func (backend *Backend) StateAndHeaderByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*state.StateDB, *types.Header, error) {
+	panic("not implemented") // TODO: Implement
+}
+
+func (backend *Backend) GetReceipts(ctx context.Context, hash common.Hash) (types.Receipts, error) {
+	panic("not implemented") // TODO: Implement
+}
+
+func (backend *Backend) GetTd(ctx context.Context, hash common.Hash) *big.Int {
+	panic("not implemented") // TODO: Implement
+}
+
+func (backend *Backend) GetEVM(ctx context.Context, msg core.Message, state *state.StateDB, header *types.Header, vmConfig *vm.Config) (*vm.EVM, func() error, error) {
+	panic("not implemented") // TODO: Implement
+}
+
+func (backend *Backend) SubscribeChainEvent(ch chan<- core.ChainEvent) event.Subscription {
+	panic("not implemented") // TODO: Implement
+}
+
+func (backend *Backend) SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) event.Subscription {
+	panic("not implemented") // TODO: Implement
+}
+
+func (backend *Backend) SubscribeChainSideEvent(ch chan<- core.ChainSideEvent) event.Subscription {
+	panic("not implemented") // TODO: Implement
+}
+
+// Transaction pool API
+func (backend *Backend) SendTx(ctx context.Context, signedTx *types.Transaction) error {
+	panic("not implemented") // TODO: Implement
+}
+
+func (backend *Backend) GetTransaction(ctx context.Context, txHash common.Hash) (*types.Transaction, common.Hash, uint64, uint64, error) {
+	panic("not implemented") // TODO: Implement
+}
+
+func (backend *Backend) GetPoolTransactions() (types.Transactions, error) {
+	panic("not implemented") // TODO: Implement
+}
+
+func (backend *Backend) GetPoolTransaction(txHash common.Hash) *types.Transaction {
+	panic("not implemented") // TODO: Implement
+}
+
+func (backend *Backend) GetPoolNonce(ctx context.Context, addr common.Address) (uint64, error) {
+	panic("not implemented") // TODO: Implement
+}
+
+func (backend *Backend) Stats() (pending int, queued int) {
+	panic("not implemented") // TODO: Implement
+}
+
+func (backend *Backend) TxPoolContent() (map[common.Address]types.Transactions, map[common.Address]types.Transactions) {
+	panic("not implemented") // TODO: Implement
+}
+
+func (backend *Backend) TxPoolContentFrom(addr common.Address) (types.Transactions, types.Transactions) {
+	panic("not implemented") // TODO: Implement
+}
+
+func (backend *Backend) SubscribeNewTxsEvent(_ chan<- core.NewTxsEvent) event.Subscription {
+	panic("not implemented") // TODO: Implement
+}
+
+// Filter API
+func (backend *Backend) BloomStatus() (uint64, uint64) {
+	panic("not implemented") // TODO: Implement
+}
+
+func (backend *Backend) GetLogs(ctx context.Context, blockHash common.Hash) ([][]*types.Log, error) {
+	panic("not implemented") // TODO: Implement
+}
+
+func (backend *Backend) ServiceFilter(ctx context.Context, session *bloombits.MatcherSession) {
+	panic("not implemented") // TODO: Implement
+}
+
+func (backend *Backend) SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscription {
+	panic("not implemented") // TODO: Implement
+}
+
+func (backend *Backend) SubscribePendingLogsEvent(ch chan<- []*types.Log) event.Subscription {
+	panic("not implemented") // TODO: Implement
+}
+
+func (backend *Backend) SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) event.Subscription {
+	panic("not implemented") // TODO: Implement
+}
+
+func (backend *Backend) ChainConfig() *params.ChainConfig {
+	panic("not implemented") // TODO: Implement
+}
+
+func (backend *Backend) Engine() consensus.Engine {
+	panic("not implemented") // TODO: Implement
+}
+

--- a/statediff/test_helpers/mocks/service_test.go
+++ b/statediff/test_helpers/mocks/service_test.go
@@ -70,7 +70,7 @@ var (
 		bankAccount,
 	})
 	mockTotalDifficulty = big.NewInt(1337)
-	params              = statediff.Params{
+	parameters              = statediff.Params{
 		IntermediateStateNodes: false,
 		IncludeTD:              true,
 		IncludeBlock:           true,
@@ -176,7 +176,7 @@ func testSubscriptionAPI(t *testing.T) {
 		}
 	}()
 	time.Sleep(1)
-	mockService.Subscribe(id, payloadChan, quitChan, params)
+	mockService.Subscribe(id, payloadChan, quitChan, parameters)
 	blockChan <- block1
 	parentBlockChain <- block0
 	wg.Wait()
@@ -234,7 +234,7 @@ func testHTTPAPI(t *testing.T) {
 		Builder:    statediff.NewBuilder(chain.StateCache()),
 		BlockChain: mockBlockChain,
 	}
-	payload, err := mockService.StateDiffAt(block1.Number().Uint64(), params)
+	payload, err := mockService.StateDiffAt(block1.Number().Uint64(), parameters)
 	if err != nil {
 		t.Error(err)
 	}

--- a/statediff/test_helpers/mocks/service_test.go
+++ b/statediff/test_helpers/mocks/service_test.go
@@ -70,7 +70,7 @@ var (
 		bankAccount,
 	})
 	mockTotalDifficulty = big.NewInt(1337)
-	parameters              = statediff.Params{
+	parameters          = statediff.Params{
 		IntermediateStateNodes: false,
 		IncludeTD:              true,
 		IncludeBlock:           true,


### PR DESCRIPTION
# Overview
This PR will allow users to add a flag when starting geth, indicating if we should wait for the statediff service to catch up to the head of the chain. 

* The feature has been tested using dapptools.
* The feature includes unit tests.
* The feature has __not__ been tested with mainnet data.
* The feature has __not__ been tested for performance.

# Data Structure Changes

This feature changes two major data structures used in the statediffing service.
1. `statediff/config.go` - `Config` 
  a. `WaitforSync` - This change allows us to indicate if the statediff service should wait for us to catch up to head.
2.  `statediff/service.go` - `Service`
  a. `WaitforSync` - This change allows us to indicate if the statediff service should wait for us to catch up to head.
  b. `Backend` - This backend object is necessary to query the internal API, which indicates if we have caught up to the head of the chain.

These changes have not failed any of the current unit tests under `/statediff.`

# Testing

This PR includes two unit tests. These unit tests have a new mock called `Backend.` The tests make sure that we catch up to head properly before indicating that we are all caught up.

We should test this with production data to ensure the feature is working correctly and does not incur any performance issues.