### PR TITLE
Handle all breaking changes for the patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ related-repositories/ipld-eth-db/**
 statediff/indexer/database/sql/statediffing_test_file.sql
 statediff/statediffing_test_file.sql
 statediff/known_gaps.sql
+related-repositories/foundry-test/
+related-repositories/ipld-eth-db/

--- a/statediff/builder.go
+++ b/statediff/builder.go
@@ -36,7 +36,7 @@ import (
 
 var (
 	nullHashBytes     = common.Hex2Bytes("0000000000000000000000000000000000000000000000000000000000000000")
-	emptyNode, _      = rlp.EncodeToBytes([]byte{})
+	emptyNode, _      = rlp.EncodeToBytes(&[]byte{})
 	emptyContractRoot = crypto.Keccak256Hash(emptyNode)
 	nullCodeHash      = crypto.Keccak256Hash([]byte{}).Bytes()
 )

--- a/statediff/builder_test.go
+++ b/statediff/builder_test.go
@@ -58,233 +58,233 @@ var (
 	slot2StorageValue = common.Hex2Bytes("09")
 	slot3StorageValue = common.Hex2Bytes("03")
 
-	slot0StorageLeafNode, _ = rlp.EncodeToBytes([]interface{}{
+	slot0StorageLeafNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("390decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563"),
 		slot0StorageValue,
 	})
-	slot1StorageLeafNode, _ = rlp.EncodeToBytes([]interface{}{
+	slot1StorageLeafNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("310e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6"),
 		slot1StorageValue,
 	})
-	slot2StorageLeafNode, _ = rlp.EncodeToBytes([]interface{}{
+	slot2StorageLeafNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("305787fa12a823e0f2b7631cc41b3ba8828b3321ca811111fa75cd3aa3bb5ace"),
 		slot2StorageValue,
 	})
-	slot3StorageLeafNode, _ = rlp.EncodeToBytes([]interface{}{
+	slot3StorageLeafNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("32575a0e9e593c00f959f8c92f12db2869c3395a3b0502d05e2516446f71f85b"),
 		slot3StorageValue,
 	})
 
-	contractAccountAtBlock2, _ = rlp.EncodeToBytes(types.StateAccount{
+	contractAccountAtBlock2, _ = rlp.EncodeToBytes(&types.StateAccount{
 		Nonce:    1,
 		Balance:  big.NewInt(0),
 		CodeHash: common.HexToHash("0xaaea5efba4fd7b45d7ec03918ac5d8b31aa93b48986af0e6b591f0f087c80127").Bytes(),
 		Root:     crypto.Keccak256Hash(block2StorageBranchRootNode),
 	})
-	contractAccountAtBlock2LeafNode, _ = rlp.EncodeToBytes([]interface{}{
+	contractAccountAtBlock2LeafNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("3114658a74d9cc9f7acf2c5cd696c3494d7c344d78bfec3add0d91ec4e8d1c45"),
 		contractAccountAtBlock2,
 	})
-	contractAccountAtBlock3, _ = rlp.EncodeToBytes(types.StateAccount{
+	contractAccountAtBlock3, _ = rlp.EncodeToBytes(&types.StateAccount{
 		Nonce:    1,
 		Balance:  big.NewInt(0),
 		CodeHash: common.HexToHash("0xaaea5efba4fd7b45d7ec03918ac5d8b31aa93b48986af0e6b591f0f087c80127").Bytes(),
 		Root:     crypto.Keccak256Hash(block3StorageBranchRootNode),
 	})
-	contractAccountAtBlock3LeafNode, _ = rlp.EncodeToBytes([]interface{}{
+	contractAccountAtBlock3LeafNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("3114658a74d9cc9f7acf2c5cd696c3494d7c344d78bfec3add0d91ec4e8d1c45"),
 		contractAccountAtBlock3,
 	})
-	contractAccountAtBlock4, _ = rlp.EncodeToBytes(types.StateAccount{
+	contractAccountAtBlock4, _ = rlp.EncodeToBytes(&types.StateAccount{
 		Nonce:    1,
 		Balance:  big.NewInt(0),
 		CodeHash: common.HexToHash("0xaaea5efba4fd7b45d7ec03918ac5d8b31aa93b48986af0e6b591f0f087c80127").Bytes(),
 		Root:     crypto.Keccak256Hash(block4StorageBranchRootNode),
 	})
-	contractAccountAtBlock4LeafNode, _ = rlp.EncodeToBytes([]interface{}{
+	contractAccountAtBlock4LeafNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("3114658a74d9cc9f7acf2c5cd696c3494d7c344d78bfec3add0d91ec4e8d1c45"),
 		contractAccountAtBlock4,
 	})
-	contractAccountAtBlock5, _ = rlp.EncodeToBytes(types.StateAccount{
+	contractAccountAtBlock5, _ = rlp.EncodeToBytes(&types.StateAccount{
 		Nonce:    1,
 		Balance:  big.NewInt(0),
 		CodeHash: common.HexToHash("0xaaea5efba4fd7b45d7ec03918ac5d8b31aa93b48986af0e6b591f0f087c80127").Bytes(),
 		Root:     crypto.Keccak256Hash(block5StorageBranchRootNode),
 	})
-	contractAccountAtBlock5LeafNode, _ = rlp.EncodeToBytes([]interface{}{
+	contractAccountAtBlock5LeafNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("3114658a74d9cc9f7acf2c5cd696c3494d7c344d78bfec3add0d91ec4e8d1c45"),
 		contractAccountAtBlock5,
 	})
 
-	minerAccountAtBlock1, _ = rlp.EncodeToBytes(types.StateAccount{
+	minerAccountAtBlock1, _ = rlp.EncodeToBytes(&types.StateAccount{
 		Nonce:    0,
 		Balance:  big.NewInt(2000002625000000000),
 		CodeHash: test_helpers.NullCodeHash.Bytes(),
 		Root:     test_helpers.EmptyContractRoot,
 	})
-	minerAccountAtBlock1LeafNode, _ = rlp.EncodeToBytes([]interface{}{
+	minerAccountAtBlock1LeafNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("3380c7b7ae81a58eb98d9c78de4a1fd7fd9535fc953ed2be602daaa41767312a"),
 		minerAccountAtBlock1,
 	})
-	minerAccountAtBlock2, _ = rlp.EncodeToBytes(types.StateAccount{
+	minerAccountAtBlock2, _ = rlp.EncodeToBytes(&types.StateAccount{
 		Nonce:    0,
 		Balance:  big.NewInt(4000111203461610525),
 		CodeHash: test_helpers.NullCodeHash.Bytes(),
 		Root:     test_helpers.EmptyContractRoot,
 	})
-	minerAccountAtBlock2LeafNode, _ = rlp.EncodeToBytes([]interface{}{
+	minerAccountAtBlock2LeafNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("3380c7b7ae81a58eb98d9c78de4a1fd7fd9535fc953ed2be602daaa41767312a"),
 		minerAccountAtBlock2,
 	})
 
-	account1AtBlock1, _ = rlp.EncodeToBytes(types.StateAccount{
+	account1AtBlock1, _ = rlp.EncodeToBytes(&types.StateAccount{
 		Nonce:    0,
 		Balance:  test_helpers.Block1Account1Balance,
 		CodeHash: test_helpers.NullCodeHash.Bytes(),
 		Root:     test_helpers.EmptyContractRoot,
 	})
-	account1AtBlock1LeafNode, _ = rlp.EncodeToBytes([]interface{}{
+	account1AtBlock1LeafNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("3926db69aaced518e9b9f0f434a473e7174109c943548bb8f23be41ca76d9ad2"),
 		account1AtBlock1,
 	})
-	account1AtBlock2, _ = rlp.EncodeToBytes(types.StateAccount{
+	account1AtBlock2, _ = rlp.EncodeToBytes(&types.StateAccount{
 		Nonce:    2,
 		Balance:  big.NewInt(999555797000009000),
 		CodeHash: test_helpers.NullCodeHash.Bytes(),
 		Root:     test_helpers.EmptyContractRoot,
 	})
-	account1AtBlock2LeafNode, _ = rlp.EncodeToBytes([]interface{}{
+	account1AtBlock2LeafNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("3926db69aaced518e9b9f0f434a473e7174109c943548bb8f23be41ca76d9ad2"),
 		account1AtBlock2,
 	})
-	account1AtBlock5, _ = rlp.EncodeToBytes(types.StateAccount{
+	account1AtBlock5, _ = rlp.EncodeToBytes(&types.StateAccount{
 		Nonce:    2,
 		Balance:  big.NewInt(2999586469962854280),
 		CodeHash: test_helpers.NullCodeHash.Bytes(),
 		Root:     test_helpers.EmptyContractRoot,
 	})
-	account1AtBlock5LeafNode, _ = rlp.EncodeToBytes([]interface{}{
+	account1AtBlock5LeafNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("3926db69aaced518e9b9f0f434a473e7174109c943548bb8f23be41ca76d9ad2"),
 		account1AtBlock5,
 	})
-	account1AtBlock6, _ = rlp.EncodeToBytes(types.StateAccount{
+	account1AtBlock6, _ = rlp.EncodeToBytes(&types.StateAccount{
 		Nonce:    3,
 		Balance:  big.NewInt(2999557977962854280),
 		CodeHash: test_helpers.NullCodeHash.Bytes(),
 		Root:     test_helpers.EmptyContractRoot,
 	})
-	account1AtBlock6LeafNode, _ = rlp.EncodeToBytes([]interface{}{
+	account1AtBlock6LeafNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("3926db69aaced518e9b9f0f434a473e7174109c943548bb8f23be41ca76d9ad2"),
 		account1AtBlock6,
 	})
 
-	account2AtBlock2, _ = rlp.EncodeToBytes(types.StateAccount{
+	account2AtBlock2, _ = rlp.EncodeToBytes(&types.StateAccount{
 		Nonce:    0,
 		Balance:  big.NewInt(1000),
 		CodeHash: test_helpers.NullCodeHash.Bytes(),
 		Root:     test_helpers.EmptyContractRoot,
 	})
-	account2AtBlock2LeafNode, _ = rlp.EncodeToBytes([]interface{}{
+	account2AtBlock2LeafNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("3957f3e2f04a0764c3a0491b175f69926da61efbcc8f61fa1455fd2d2b4cdd45"),
 		account2AtBlock2,
 	})
-	account2AtBlock3, _ = rlp.EncodeToBytes(types.StateAccount{
+	account2AtBlock3, _ = rlp.EncodeToBytes(&types.StateAccount{
 		Nonce:    0,
 		Balance:  big.NewInt(2000013574009435976),
 		CodeHash: test_helpers.NullCodeHash.Bytes(),
 		Root:     test_helpers.EmptyContractRoot,
 	})
-	account2AtBlock3LeafNode, _ = rlp.EncodeToBytes([]interface{}{
+	account2AtBlock3LeafNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("3957f3e2f04a0764c3a0491b175f69926da61efbcc8f61fa1455fd2d2b4cdd45"),
 		account2AtBlock3,
 	})
-	account2AtBlock4, _ = rlp.EncodeToBytes(types.StateAccount{
+	account2AtBlock4, _ = rlp.EncodeToBytes(&types.StateAccount{
 		Nonce:    0,
 		Balance:  big.NewInt(4000048088163070348),
 		CodeHash: test_helpers.NullCodeHash.Bytes(),
 		Root:     test_helpers.EmptyContractRoot,
 	})
-	account2AtBlock4LeafNode, _ = rlp.EncodeToBytes([]interface{}{
+	account2AtBlock4LeafNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("3957f3e2f04a0764c3a0491b175f69926da61efbcc8f61fa1455fd2d2b4cdd45"),
 		account2AtBlock4,
 	})
-	account2AtBlock6, _ = rlp.EncodeToBytes(types.StateAccount{
+	account2AtBlock6, _ = rlp.EncodeToBytes(&types.StateAccount{
 		Nonce:    0,
 		Balance:  big.NewInt(6000063258066544204),
 		CodeHash: test_helpers.NullCodeHash.Bytes(),
 		Root:     test_helpers.EmptyContractRoot,
 	})
-	account2AtBlock6LeafNode, _ = rlp.EncodeToBytes([]interface{}{
+	account2AtBlock6LeafNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("3957f3e2f04a0764c3a0491b175f69926da61efbcc8f61fa1455fd2d2b4cdd45"),
 		account2AtBlock6,
 	})
 
-	bankAccountAtBlock0, _ = rlp.EncodeToBytes(types.StateAccount{
+	bankAccountAtBlock0, _ = rlp.EncodeToBytes(&types.StateAccount{
 		Nonce:    0,
 		Balance:  big.NewInt(test_helpers.TestBankFunds.Int64()),
 		CodeHash: test_helpers.NullCodeHash.Bytes(),
 		Root:     test_helpers.EmptyContractRoot,
 	})
-	bankAccountAtBlock0LeafNode, _ = rlp.EncodeToBytes([]interface{}{
+	bankAccountAtBlock0LeafNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("2000bf49f440a1cd0527e4d06e2765654c0f56452257516d793a9b8d604dcfdf2a"),
 		bankAccountAtBlock0,
 	})
 
 	block1BankBalance      = big.NewInt(test_helpers.TestBankFunds.Int64() - test_helpers.BalanceChange10000 - test_helpers.GasFees)
-	bankAccountAtBlock1, _ = rlp.EncodeToBytes(types.StateAccount{
+	bankAccountAtBlock1, _ = rlp.EncodeToBytes(&types.StateAccount{
 		Nonce:    1,
 		Balance:  block1BankBalance,
 		CodeHash: test_helpers.NullCodeHash.Bytes(),
 		Root:     test_helpers.EmptyContractRoot,
 	})
-	bankAccountAtBlock1LeafNode, _ = rlp.EncodeToBytes([]interface{}{
+	bankAccountAtBlock1LeafNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("30bf49f440a1cd0527e4d06e2765654c0f56452257516d793a9b8d604dcfdf2a"),
 		bankAccountAtBlock1,
 	})
 
 	block2BankBalance      = block1BankBalance.Int64() - test_helpers.BalanceChange1Ether - test_helpers.GasFees
-	bankAccountAtBlock2, _ = rlp.EncodeToBytes(types.StateAccount{
+	bankAccountAtBlock2, _ = rlp.EncodeToBytes(&types.StateAccount{
 		Nonce:    2,
 		Balance:  big.NewInt(block2BankBalance),
 		CodeHash: test_helpers.NullCodeHash.Bytes(),
 		Root:     test_helpers.EmptyContractRoot,
 	})
-	bankAccountAtBlock2LeafNode, _ = rlp.EncodeToBytes([]interface{}{
+	bankAccountAtBlock2LeafNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("30bf49f440a1cd0527e4d06e2765654c0f56452257516d793a9b8d604dcfdf2a"),
 		bankAccountAtBlock2,
 	})
-	bankAccountAtBlock3, _ = rlp.EncodeToBytes(types.StateAccount{
+	bankAccountAtBlock3, _ = rlp.EncodeToBytes(&types.StateAccount{
 		Nonce:    3,
 		Balance:  big.NewInt(999914255999990000),
 		CodeHash: test_helpers.NullCodeHash.Bytes(),
 		Root:     test_helpers.EmptyContractRoot,
 	})
-	bankAccountAtBlock3LeafNode, _ = rlp.EncodeToBytes([]interface{}{
+	bankAccountAtBlock3LeafNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("30bf49f440a1cd0527e4d06e2765654c0f56452257516d793a9b8d604dcfdf2a"),
 		bankAccountAtBlock3,
 	})
-	bankAccountAtBlock4, _ = rlp.EncodeToBytes(types.StateAccount{
+	bankAccountAtBlock4, _ = rlp.EncodeToBytes(&types.StateAccount{
 		Nonce:    6,
 		Balance:  big.NewInt(999826859999990000),
 		CodeHash: test_helpers.NullCodeHash.Bytes(),
 		Root:     test_helpers.EmptyContractRoot,
 	})
-	bankAccountAtBlock4LeafNode, _ = rlp.EncodeToBytes([]interface{}{
+	bankAccountAtBlock4LeafNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("30bf49f440a1cd0527e4d06e2765654c0f56452257516d793a9b8d604dcfdf2a"),
 		bankAccountAtBlock4,
 	})
-	bankAccountAtBlock5, _ = rlp.EncodeToBytes(types.StateAccount{
+	bankAccountAtBlock5, _ = rlp.EncodeToBytes(&types.StateAccount{
 		Nonce:    8,
 		Balance:  big.NewInt(999761283999990000),
 		CodeHash: test_helpers.NullCodeHash.Bytes(),
 		Root:     test_helpers.EmptyContractRoot,
 	})
-	bankAccountAtBlock5LeafNode, _ = rlp.EncodeToBytes([]interface{}{
+	bankAccountAtBlock5LeafNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("30bf49f440a1cd0527e4d06e2765654c0f56452257516d793a9b8d604dcfdf2a"),
 		bankAccountAtBlock5,
 	})
 
-	block1BranchRootNode, _ = rlp.EncodeToBytes([]interface{}{
+	block1BranchRootNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		crypto.Keccak256(bankAccountAtBlock1LeafNode),
 		[]byte{},
 		[]byte{},
@@ -303,7 +303,7 @@ var (
 		[]byte{},
 		[]byte{},
 	})
-	block2BranchRootNode, _ = rlp.EncodeToBytes([]interface{}{
+	block2BranchRootNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		crypto.Keccak256(bankAccountAtBlock2LeafNode),
 		[]byte{},
 		[]byte{},
@@ -322,7 +322,7 @@ var (
 		[]byte{},
 		[]byte{},
 	})
-	block3BranchRootNode, _ = rlp.EncodeToBytes([]interface{}{
+	block3BranchRootNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		crypto.Keccak256(bankAccountAtBlock3LeafNode),
 		[]byte{},
 		[]byte{},
@@ -341,7 +341,7 @@ var (
 		[]byte{},
 		[]byte{},
 	})
-	block4BranchRootNode, _ = rlp.EncodeToBytes([]interface{}{
+	block4BranchRootNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		crypto.Keccak256(bankAccountAtBlock4LeafNode),
 		[]byte{},
 		[]byte{},
@@ -360,7 +360,7 @@ var (
 		[]byte{},
 		[]byte{},
 	})
-	block5BranchRootNode, _ = rlp.EncodeToBytes([]interface{}{
+	block5BranchRootNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		crypto.Keccak256(bankAccountAtBlock5LeafNode),
 		[]byte{},
 		[]byte{},
@@ -379,7 +379,7 @@ var (
 		[]byte{},
 		[]byte{},
 	})
-	block6BranchRootNode, _ = rlp.EncodeToBytes([]interface{}{
+	block6BranchRootNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		crypto.Keccak256(bankAccountAtBlock5LeafNode),
 		[]byte{},
 		[]byte{},
@@ -399,7 +399,7 @@ var (
 		[]byte{},
 	})
 
-	block2StorageBranchRootNode, _ = rlp.EncodeToBytes([]interface{}{
+	block2StorageBranchRootNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		[]byte{},
 		[]byte{},
 		crypto.Keccak256(slot0StorageLeafNode),
@@ -418,7 +418,7 @@ var (
 		[]byte{},
 		[]byte{},
 	})
-	block3StorageBranchRootNode, _ = rlp.EncodeToBytes([]interface{}{
+	block3StorageBranchRootNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		[]byte{},
 		[]byte{},
 		crypto.Keccak256(slot0StorageLeafNode),
@@ -437,7 +437,7 @@ var (
 		[]byte{},
 		[]byte{},
 	})
-	block4StorageBranchRootNode, _ = rlp.EncodeToBytes([]interface{}{
+	block4StorageBranchRootNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		[]byte{},
 		[]byte{},
 		crypto.Keccak256(slot0StorageLeafNode),
@@ -456,7 +456,7 @@ var (
 		[]byte{},
 		[]byte{},
 	})
-	block5StorageBranchRootNode, _ = rlp.EncodeToBytes([]interface{}{
+	block5StorageBranchRootNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		[]byte{},
 		[]byte{},
 		crypto.Keccak256(slot0StorageLeafNode),
@@ -698,11 +698,11 @@ func TestBuilder(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		receivedStateDiffRlp, err := rlp.EncodeToBytes(diff)
+		receivedStateDiffRlp, err := rlp.EncodeToBytes(&diff)
 		if err != nil {
 			t.Error(err)
 		}
-		expectedStateDiffRlp, err := rlp.EncodeToBytes(test.expected)
+		expectedStateDiffRlp, err := rlp.EncodeToBytes(&test.expected)
 		if err != nil {
 			t.Error(err)
 		}
@@ -961,11 +961,11 @@ func TestBuilderWithIntermediateNodes(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		receivedStateDiffRlp, err := rlp.EncodeToBytes(diff)
+		receivedStateDiffRlp, err := rlp.EncodeToBytes(&diff)
 		if err != nil {
 			t.Error(err)
 		}
-		expectedStateDiffRlp, err := rlp.EncodeToBytes(test.expected)
+		expectedStateDiffRlp, err := rlp.EncodeToBytes(&test.expected)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1151,11 +1151,11 @@ func TestBuilderWithWatchedAddressList(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		receivedStateDiffRlp, err := rlp.EncodeToBytes(diff)
+		receivedStateDiffRlp, err := rlp.EncodeToBytes(&diff)
 		if err != nil {
 			t.Error(err)
 		}
-		expectedStateDiffRlp, err := rlp.EncodeToBytes(test.expected)
+		expectedStateDiffRlp, err := rlp.EncodeToBytes(&test.expected)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1381,11 +1381,11 @@ func TestBuilderWithRemovedAccountAndStorage(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		receivedStateDiffRlp, err := rlp.EncodeToBytes(diff)
+		receivedStateDiffRlp, err := rlp.EncodeToBytes(&diff)
 		if err != nil {
 			t.Error(err)
 		}
-		expectedStateDiffRlp, err := rlp.EncodeToBytes(test.expected)
+		expectedStateDiffRlp, err := rlp.EncodeToBytes(&test.expected)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1578,12 +1578,12 @@ func TestBuilderWithRemovedAccountAndStorageWithoutIntermediateNodes(t *testing.
 		if err != nil {
 			t.Error(err)
 		}
-		receivedStateDiffRlp, err := rlp.EncodeToBytes(diff)
+		receivedStateDiffRlp, err := rlp.EncodeToBytes(&diff)
 		if err != nil {
 			t.Error(err)
 		}
 
-		expectedStateDiffRlp, err := rlp.EncodeToBytes(test.expected)
+		expectedStateDiffRlp, err := rlp.EncodeToBytes(&test.expected)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1696,12 +1696,12 @@ func TestBuilderWithRemovedNonWatchedAccount(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		receivedStateDiffRlp, err := rlp.EncodeToBytes(diff)
+		receivedStateDiffRlp, err := rlp.EncodeToBytes(&diff)
 		if err != nil {
 			t.Error(err)
 		}
 
-		expectedStateDiffRlp, err := rlp.EncodeToBytes(test.expected)
+		expectedStateDiffRlp, err := rlp.EncodeToBytes(&test.expected)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1866,12 +1866,12 @@ func TestBuilderWithRemovedWatchedAccount(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		receivedStateDiffRlp, err := rlp.EncodeToBytes(diff)
+		receivedStateDiffRlp, err := rlp.EncodeToBytes(&diff)
 		if err != nil {
 			t.Error(err)
 		}
 
-		expectedStateDiffRlp, err := rlp.EncodeToBytes(test.expected)
+		expectedStateDiffRlp, err := rlp.EncodeToBytes(&test.expected)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1888,44 +1888,44 @@ func TestBuilderWithRemovedWatchedAccount(t *testing.T) {
 var (
 	slot00StorageValue = common.Hex2Bytes("9471562b71999873db5b286df957af199ec94617f7") // prefixed TestBankAddress
 
-	slot00StorageLeafNode, _ = rlp.EncodeToBytes([]interface{}{
+	slot00StorageLeafNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("390decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563"),
 		slot00StorageValue,
 	})
 
-	contractAccountAtBlock01, _ = rlp.EncodeToBytes(types.StateAccount{
+	contractAccountAtBlock01, _ = rlp.EncodeToBytes(&types.StateAccount{
 		Nonce:    1,
 		Balance:  big.NewInt(0),
 		CodeHash: common.HexToHash("0xaaea5efba4fd7b45d7ec03918ac5d8b31aa93b48986af0e6b591f0f087c80127").Bytes(),
 		Root:     crypto.Keccak256Hash(block01StorageBranchRootNode),
 	})
-	contractAccountAtBlock01LeafNode, _ = rlp.EncodeToBytes([]interface{}{
+	contractAccountAtBlock01LeafNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("3cb2583748c26e89ef19c2a8529b05a270f735553b4d44b6f2a1894987a71c8b"),
 		contractAccountAtBlock01,
 	})
 
-	bankAccountAtBlock01, _ = rlp.EncodeToBytes(types.StateAccount{
+	bankAccountAtBlock01, _ = rlp.EncodeToBytes(&types.StateAccount{
 		Nonce:    1,
 		Balance:  big.NewInt(3999629697375000000),
 		CodeHash: test_helpers.NullCodeHash.Bytes(),
 		Root:     test_helpers.EmptyContractRoot,
 	})
-	bankAccountAtBlock01LeafNode, _ = rlp.EncodeToBytes([]interface{}{
+	bankAccountAtBlock01LeafNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("30bf49f440a1cd0527e4d06e2765654c0f56452257516d793a9b8d604dcfdf2a"),
 		bankAccountAtBlock01,
 	})
-	bankAccountAtBlock02, _ = rlp.EncodeToBytes(types.StateAccount{
+	bankAccountAtBlock02, _ = rlp.EncodeToBytes(&types.StateAccount{
 		Nonce:    2,
 		Balance:  big.NewInt(5999607323457344852),
 		CodeHash: test_helpers.NullCodeHash.Bytes(),
 		Root:     test_helpers.EmptyContractRoot,
 	})
-	bankAccountAtBlock02LeafNode, _ = rlp.EncodeToBytes([]interface{}{
+	bankAccountAtBlock02LeafNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("2000bf49f440a1cd0527e4d06e2765654c0f56452257516d793a9b8d604dcfdf2a"),
 		bankAccountAtBlock02,
 	})
 
-	block01BranchRootNode, _ = rlp.EncodeToBytes([]interface{}{
+	block01BranchRootNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		crypto.Keccak256Hash(bankAccountAtBlock01LeafNode),
 		crypto.Keccak256Hash(contractAccountAtBlock01LeafNode),
 		[]byte{},
@@ -1945,7 +1945,7 @@ var (
 		[]byte{},
 	})
 
-	block01StorageBranchRootNode, _ = rlp.EncodeToBytes([]interface{}{
+	block01StorageBranchRootNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		[]byte{},
 		[]byte{},
 		crypto.Keccak256(slot00StorageLeafNode),
@@ -2099,11 +2099,11 @@ func TestBuilderWithMovedAccount(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		receivedStateDiffRlp, err := rlp.EncodeToBytes(diff)
+		receivedStateDiffRlp, err := rlp.EncodeToBytes(&diff)
 		if err != nil {
 			t.Error(err)
 		}
-		expectedStateDiffRlp, err := rlp.EncodeToBytes(test.expected)
+		expectedStateDiffRlp, err := rlp.EncodeToBytes(&test.expected)
 		if err != nil {
 			t.Error(err)
 		}
@@ -2235,11 +2235,11 @@ func TestBuilderWithMovedAccountOnlyLeafs(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		receivedStateDiffRlp, err := rlp.EncodeToBytes(diff)
+		receivedStateDiffRlp, err := rlp.EncodeToBytes(&diff)
 		if err != nil {
 			t.Error(err)
 		}
-		expectedStateDiffRlp, err := rlp.EncodeToBytes(test.expected)
+		expectedStateDiffRlp, err := rlp.EncodeToBytes(&test.expected)
 		if err != nil {
 			t.Error(err)
 		}
@@ -2466,11 +2466,11 @@ func TestBuildStateTrie(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		receivedStateTrieRlp, err := rlp.EncodeToBytes(diff)
+		receivedStateTrieRlp, err := rlp.EncodeToBytes(&diff)
 		if err != nil {
 			t.Error(err)
 		}
-		expectedStateTrieRlp, err := rlp.EncodeToBytes(test.expected)
+		expectedStateTrieRlp, err := rlp.EncodeToBytes(&test.expected)
 		if err != nil {
 			t.Error(err)
 		}

--- a/statediff/builder_test.go
+++ b/statediff/builder_test.go
@@ -702,7 +702,7 @@ func TestBuilder(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		expectedStateDiffRlp, err := rlp.EncodeToBytes(&test.expected)
+		expectedStateDiffRlp, err := rlp.EncodeToBytes(test.expected)
 		if err != nil {
 			t.Error(err)
 		}
@@ -965,7 +965,7 @@ func TestBuilderWithIntermediateNodes(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		expectedStateDiffRlp, err := rlp.EncodeToBytes(&test.expected)
+		expectedStateDiffRlp, err := rlp.EncodeToBytes(test.expected)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1155,7 +1155,7 @@ func TestBuilderWithWatchedAddressList(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		expectedStateDiffRlp, err := rlp.EncodeToBytes(&test.expected)
+		expectedStateDiffRlp, err := rlp.EncodeToBytes(test.expected)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1385,7 +1385,7 @@ func TestBuilderWithRemovedAccountAndStorage(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		expectedStateDiffRlp, err := rlp.EncodeToBytes(&test.expected)
+		expectedStateDiffRlp, err := rlp.EncodeToBytes(test.expected)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1583,7 +1583,7 @@ func TestBuilderWithRemovedAccountAndStorageWithoutIntermediateNodes(t *testing.
 			t.Error(err)
 		}
 
-		expectedStateDiffRlp, err := rlp.EncodeToBytes(&test.expected)
+		expectedStateDiffRlp, err := rlp.EncodeToBytes(test.expected)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1701,7 +1701,7 @@ func TestBuilderWithRemovedNonWatchedAccount(t *testing.T) {
 			t.Error(err)
 		}
 
-		expectedStateDiffRlp, err := rlp.EncodeToBytes(&test.expected)
+		expectedStateDiffRlp, err := rlp.EncodeToBytes(test.expected)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1871,7 +1871,7 @@ func TestBuilderWithRemovedWatchedAccount(t *testing.T) {
 			t.Error(err)
 		}
 
-		expectedStateDiffRlp, err := rlp.EncodeToBytes(&test.expected)
+		expectedStateDiffRlp, err := rlp.EncodeToBytes(test.expected)
 		if err != nil {
 			t.Error(err)
 		}
@@ -2103,7 +2103,7 @@ func TestBuilderWithMovedAccount(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		expectedStateDiffRlp, err := rlp.EncodeToBytes(&test.expected)
+		expectedStateDiffRlp, err := rlp.EncodeToBytes(test.expected)
 		if err != nil {
 			t.Error(err)
 		}
@@ -2239,7 +2239,7 @@ func TestBuilderWithMovedAccountOnlyLeafs(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		expectedStateDiffRlp, err := rlp.EncodeToBytes(&test.expected)
+		expectedStateDiffRlp, err := rlp.EncodeToBytes(test.expected)
 		if err != nil {
 			t.Error(err)
 		}
@@ -2470,7 +2470,7 @@ func TestBuildStateTrie(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		expectedStateTrieRlp, err := rlp.EncodeToBytes(&test.expected)
+		expectedStateTrieRlp, err := rlp.EncodeToBytes(test.expected)
 		if err != nil {
 			t.Error(err)
 		}

--- a/statediff/indexer/database/sql/pgx_indexer_test.go
+++ b/statediff/indexer/database/sql/pgx_indexer_test.go
@@ -286,12 +286,12 @@ func TestPGXIndexer(t *testing.T) {
 				err = rlp.DecodeBytes(r.Data, &nodeElements)
 				require.NoError(t, err)
 				if len(nodeElements) == 2 {
-					logRaw, err := rlp.EncodeToBytes(expectedLogs[idx])
+					logRaw, err := rlp.EncodeToBytes(&expectedLogs[idx])
 					require.NoError(t, err)
 					// 2nd element of the leaf node contains the encoded log data.
 					test_helpers.ExpectEqual(t, logRaw, nodeElements[1].([]byte))
 				} else {
-					logRaw, err := rlp.EncodeToBytes(expectedLogs[idx])
+					logRaw, err := rlp.EncodeToBytes(&expectedLogs[idx])
 					require.NoError(t, err)
 					// raw log was IPLDized
 					test_helpers.ExpectEqual(t, logRaw, r.Data)

--- a/statediff/indexer/database/sql/sqlx_indexer_test.go
+++ b/statediff/indexer/database/sql/sqlx_indexer_test.go
@@ -280,12 +280,12 @@ func TestSQLXIndexer(t *testing.T) {
 				err = rlp.DecodeBytes(r.Data, &nodeElements)
 				require.NoError(t, err)
 				if len(nodeElements) == 2 {
-					logRaw, err := rlp.EncodeToBytes(expectedLogs[idx])
+					logRaw, err := rlp.EncodeToBytes(&expectedLogs[idx])
 					require.NoError(t, err)
 					// 2nd element of the leaf node contains the encoded log data.
 					test_helpers.ExpectEqual(t, logRaw, nodeElements[1].([]byte))
 				} else {
-					logRaw, err := rlp.EncodeToBytes(expectedLogs[idx])
+					logRaw, err := rlp.EncodeToBytes(&expectedLogs[idx])
 					require.NoError(t, err)
 					// raw log was IPLDized
 					test_helpers.ExpectEqual(t, logRaw, r.Data)

--- a/statediff/indexer/ipld/eth_header.go
+++ b/statediff/indexer/ipld/eth_header.go
@@ -46,7 +46,7 @@ var _ node.Node = (*EthHeader)(nil)
 
 // NewEthHeader converts a *types.Header into an EthHeader IPLD node
 func NewEthHeader(header *types.Header) (*EthHeader, error) {
-	headerRLP, err := rlp.EncodeToBytes(header)
+	headerRLP, err := rlp.EncodeToBytes(&header)
 	if err != nil {
 		return nil, err
 	}

--- a/statediff/indexer/ipld/eth_header.go
+++ b/statediff/indexer/ipld/eth_header.go
@@ -46,7 +46,7 @@ var _ node.Node = (*EthHeader)(nil)
 
 // NewEthHeader converts a *types.Header into an EthHeader IPLD node
 func NewEthHeader(header *types.Header) (*EthHeader, error) {
-	headerRLP, err := rlp.EncodeToBytes(&header)
+	headerRLP, err := rlp.EncodeToBytes(header)
 	if err != nil {
 		return nil, err
 	}

--- a/statediff/indexer/ipld/eth_parser.go
+++ b/statediff/indexer/ipld/eth_parser.go
@@ -102,7 +102,7 @@ func FromBlockJSON(r io.Reader) (*EthHeader, []*EthTx, []*EthTxTrie, error) {
 		return nil, nil, nil, err
 	}
 
-	headerRawData := getRLP(obj.Result.Header)
+	headerRawData := getRLP(&obj.Result.Header)
 	c, err := RawdataToCid(MEthHeader, headerRawData, multihash.KECCAK_256)
 	if err != nil {
 		return nil, nil, nil, err

--- a/statediff/indexer/mocks/test_data.go
+++ b/statediff/indexer/mocks/test_data.go
@@ -123,7 +123,7 @@ var (
 	MockStorageLeafKey  = crypto.Keccak256Hash(mockStorageLocation[:]).Bytes()
 	StorageValue        = common.Hex2Bytes("01")
 	StoragePartialPath  = common.Hex2Bytes("20290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563")
-	StorageLeafNode, _  = rlp.EncodeToBytes([]interface{}{
+	StorageLeafNode, _  = rlp.EncodeToBytes(&[]interface{}{
 		StoragePartialPath,
 		StorageValue,
 	})
@@ -132,14 +132,14 @@ var (
 	ContractRoot       = "0x821e2556a290c86405f8160a2d662042a431ba456b9db265c79bb837c04be5f0"
 	ContractCodeHash   = common.HexToHash("0x753f98a8d4328b15636e46f66f2cb4bc860100aa17967cc145fcd17d1d4710ea")
 	ContractLeafKey    = test_helpers.AddressToLeafKey(ContractAddress)
-	ContractAccount, _ = rlp.EncodeToBytes(types.StateAccount{
+	ContractAccount, _ = rlp.EncodeToBytes(&types.StateAccount{
 		Nonce:    nonce1,
 		Balance:  big.NewInt(0),
 		CodeHash: ContractCodeHash.Bytes(),
 		Root:     common.HexToHash(ContractRoot),
 	})
 	ContractPartialPath = common.Hex2Bytes("3114658a74d9cc9f7acf2c5cd696c3494d7c344d78bfec3add0d91ec4e8d1c45")
-	ContractLeafNode, _ = rlp.EncodeToBytes([]interface{}{
+	ContractLeafNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		ContractPartialPath,
 		ContractAccount,
 	})
@@ -155,14 +155,14 @@ var (
 	AccountCodeHash = common.HexToHash("0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
 	AccountLeafKey  = test_helpers.Account2LeafKey
 	RemovedLeafKey  = test_helpers.Account1LeafKey
-	Account, _      = rlp.EncodeToBytes(types.StateAccount{
+	Account, _      = rlp.EncodeToBytes(&types.StateAccount{
 		Nonce:    nonce0,
 		Balance:  big.NewInt(1000),
 		CodeHash: AccountCodeHash.Bytes(),
 		Root:     common.HexToHash(AccountRoot),
 	})
 	AccountPartialPath = common.Hex2Bytes("3957f3e2f04a0764c3a0491b175f69926da61efbcc8f61fa1455fd2d2b4cdd45")
-	AccountLeafNode, _ = rlp.EncodeToBytes([]interface{}{
+	AccountLeafNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		AccountPartialPath,
 		Account,
 	})

--- a/statediff/known_gaps_test.go
+++ b/statediff/known_gaps_test.go
@@ -166,8 +166,8 @@ func testFindAndUpdateGaps(t *testing.T, wipeDbBeforeStart bool) {
 	startBlock := big.NewInt(0)
 	endBlock := big.NewInt(0)
 
-	startBlock.Add(latestBlockInDb, gapDifference)
-	endBlock.Sub(latestBlockOnChain, gapDifference)
+	startBlock.Add(latestBlockInDb, expectedDifference)
+	endBlock.Sub(latestBlockOnChain, expectedDifference)
 	validateUpsert(t, service, startBlock.Int64(), endBlock.Int64())
 
 }

--- a/statediff/mainnet_tests/builder_test.go
+++ b/statediff/mainnet_tests/builder_test.go
@@ -420,7 +420,7 @@ func init() {
 	}
 	db = rawdb.NewMemoryDatabase()
 	genesisBlock = core.DefaultGenesisBlock().MustCommit(db)
-	genBy, err := rlp.EncodeToBytes(&genesisBlock)
+	genBy, err := rlp.EncodeToBytes(genesisBlock)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -671,7 +671,7 @@ func TestBuilderOnMainnetBlocks(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		receivedStateDiffRlp, err := rlp.EncodeToBytes(&diff)
+		receivedStateDiffRlp, err := rlp.EncodeToBytes(diff)
 		if err != nil {
 			t.Error(err)
 		}

--- a/statediff/mainnet_tests/builder_test.go
+++ b/statediff/mainnet_tests/builder_test.go
@@ -50,18 +50,18 @@ var (
 	emptyStorage                                               = make([]sdtypes.StorageNode, 0)
 
 	// block 1 data
-	block1CoinbaseAccount, _ = rlp.EncodeToBytes(types.StateAccount{
+	block1CoinbaseAccount, _ = rlp.EncodeToBytes(&types.StateAccount{
 		Nonce:    0,
 		Balance:  big.NewInt(5000000000000000000),
 		CodeHash: test_helpers.NullCodeHash.Bytes(),
 		Root:     test_helpers.EmptyContractRoot,
 	})
-	block1CoinbaseLeafNode, _ = rlp.EncodeToBytes([]interface{}{
+	block1CoinbaseLeafNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("38251692195afc818c92b485fcb8a4691af89cbe5a2ab557b83a4261be2a9a"),
 		block1CoinbaseAccount,
 	})
 	block1CoinbaseLeafNodeHash = crypto.Keccak256(block1CoinbaseLeafNode)
-	block1x040bBranchNode, _   = rlp.EncodeToBytes([]interface{}{
+	block1x040bBranchNode, _   = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("cc947d5ebb80600bad471f12c6ad5e4981e3525ecf8a2d982cc032536ae8b66d"),
 		common.Hex2Bytes("e80e52462e635a834e90e86ccf7673a6430384aac17004d626f4db831f0624bc"),
 		common.Hex2Bytes("59a8f11f60cb0a8488831f242da02944a26fd269d0608a44b8b873ded9e59e1b"),
@@ -81,7 +81,7 @@ var (
 		[]byte{},
 	})
 	block1x040bBranchNodeHash = crypto.Keccak256(block1x040bBranchNode)
-	block1x04BranchNode, _    = rlp.EncodeToBytes([]interface{}{
+	block1x04BranchNode, _    = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("a9317a59365ca09cefcd384018696590afffc432e35a97e8f85aa48907bf3247"),
 		common.Hex2Bytes("e0bc229254ce7a6a736c3953e570ab18b4a7f5f2a9aa3c3057b5f17d250a1cad"),
 		common.Hex2Bytes("a2484ec8884dbe0cf24ece99d67df0d1fe78992d67cc777636a817cb2ef205aa"),
@@ -101,7 +101,7 @@ var (
 		[]byte{},
 	})
 	block1x04BranchNodeHash = crypto.Keccak256(block1x04BranchNode)
-	block1RootBranchNode, _ = rlp.EncodeToBytes([]interface{}{
+	block1RootBranchNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("90dcaf88c40c7bbc95a912cbdde67c175767b31173df9ee4b0d733bfdd511c43"),
 		common.Hex2Bytes("babe369f6b12092f49181ae04ca173fb68d1a5456f18d20fa32cba73954052bd"),
 		common.Hex2Bytes("473ecf8a7e36a829e75039a3b055e51b8332cbf03324ab4af2066bbd6fbf0021"),
@@ -122,30 +122,30 @@ var (
 	})
 
 	// block 2 data
-	block2CoinbaseAccount, _ = rlp.EncodeToBytes(types.StateAccount{
+	block2CoinbaseAccount, _ = rlp.EncodeToBytes(&types.StateAccount{
 		Nonce:    0,
 		Balance:  big.NewInt(5000000000000000000),
 		CodeHash: test_helpers.NullCodeHash.Bytes(),
 		Root:     test_helpers.EmptyContractRoot,
 	})
-	block2CoinbaseLeafNode, _ = rlp.EncodeToBytes([]interface{}{
+	block2CoinbaseLeafNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("20679cbcf198c1741a6f4e4473845659a30caa8b26f8d37a0be2e2bc0d8892"),
 		block2CoinbaseAccount,
 	})
 	block2CoinbaseLeafNodeHash   = crypto.Keccak256(block2CoinbaseLeafNode)
 	block2MovedPremineBalance, _ = new(big.Int).SetString("4000000000000000000000", 10)
-	block2MovedPremineAccount, _ = rlp.EncodeToBytes(types.StateAccount{
+	block2MovedPremineAccount, _ = rlp.EncodeToBytes(&types.StateAccount{
 		Nonce:    0,
 		Balance:  block2MovedPremineBalance,
 		CodeHash: test_helpers.NullCodeHash.Bytes(),
 		Root:     test_helpers.EmptyContractRoot,
 	})
-	block2MovedPremineLeafNode, _ = rlp.EncodeToBytes([]interface{}{
+	block2MovedPremineLeafNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("20f2e24db7943eab4415f99e109698863b0fecca1cf9ffc500f38cefbbe29e"),
 		block2MovedPremineAccount,
 	})
 	block2MovedPremineLeafNodeHash = crypto.Keccak256(block2MovedPremineLeafNode)
-	block2x00080dBranchNode, _     = rlp.EncodeToBytes([]interface{}{
+	block2x00080dBranchNode, _     = rlp.EncodeToBytes(&[]interface{}{
 		block2MovedPremineLeafNodeHash,
 		[]byte{},
 		[]byte{},
@@ -165,7 +165,7 @@ var (
 		[]byte{},
 	})
 	block2x00080dBranchNodeHash = crypto.Keccak256(block2x00080dBranchNode)
-	block2x0008BranchNode, _    = rlp.EncodeToBytes([]interface{}{
+	block2x0008BranchNode, _    = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("def97a26f824fc3911cf7f8c41dfc9bc93cc36ae2248de22ecae01d6950b2dc9"),
 		common.Hex2Bytes("234a575e2c5badab8de0f6515b6723195323a0562fbe1316255888637043f1c1"),
 		common.Hex2Bytes("29659740af1c23306ee8f8294c71a5632ace8c80b1eb61cfdf7022f47ff52305"),
@@ -185,7 +185,7 @@ var (
 		[]byte{},
 	})
 	block2x0008BranchNodeHash = crypto.Keccak256(block2x0008BranchNode)
-	block2x00BranchNode, _    = rlp.EncodeToBytes([]interface{}{
+	block2x00BranchNode, _    = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("e45a9e85cab1b6eb18b30df2c6acc448bbac6a30d81646823b31223e16e5063e"),
 		common.Hex2Bytes("33bd7171d556b981f6849064eb09412b24fedc0812127db936067043f53db1b9"),
 		common.Hex2Bytes("ca56945f074da4f15587404593faf3a50d17ea0e21a418ad6ec99bdf4bf3f914"),
@@ -205,7 +205,7 @@ var (
 		[]byte{},
 	})
 	block2x00BranchNodeHash = crypto.Keccak256(block2x00BranchNode)
-	block2RootBranchNode, _ = rlp.EncodeToBytes([]interface{}{
+	block2RootBranchNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		block2x00BranchNodeHash,
 		common.Hex2Bytes("babe369f6b12092f49181ae04ca173fb68d1a5456f18d20fa32cba73954052bd"),
 		common.Hex2Bytes("473ecf8a7e36a829e75039a3b055e51b8332cbf03324ab4af2066bbd6fbf0021"),
@@ -228,45 +228,45 @@ var (
 	// block3 data
 	// path 060e0f
 	blcok3CoinbaseBalance, _ = new(big.Int).SetString("5156250000000000000", 10)
-	block3CoinbaseAccount, _ = rlp.EncodeToBytes(types.StateAccount{
+	block3CoinbaseAccount, _ = rlp.EncodeToBytes(&types.StateAccount{
 		Nonce:    0,
 		Balance:  blcok3CoinbaseBalance,
 		CodeHash: test_helpers.NullCodeHash.Bytes(),
 		Root:     test_helpers.EmptyContractRoot,
 	})
-	block3CoinbaseLeafNode, _ = rlp.EncodeToBytes([]interface{}{
+	block3CoinbaseLeafNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("3a174f00e64521a535f35e67c1aa241951c791639b2f3d060f49c5d9fa8b9e"),
 		block3CoinbaseAccount,
 	})
 	block3CoinbaseLeafNodeHash = crypto.Keccak256(block3CoinbaseLeafNode)
 	// path 0c0e050703
 	block3MovedPremineBalance1, _ = new(big.Int).SetString("3750000000000000000", 10)
-	block3MovedPremineAccount1, _ = rlp.EncodeToBytes(types.StateAccount{
+	block3MovedPremineAccount1, _ = rlp.EncodeToBytes(&types.StateAccount{
 		Nonce:    0,
 		Balance:  block3MovedPremineBalance1,
 		CodeHash: test_helpers.NullCodeHash.Bytes(),
 		Root:     test_helpers.EmptyContractRoot,
 	})
-	block3MovedPremineLeafNode1, _ = rlp.EncodeToBytes([]interface{}{
+	block3MovedPremineLeafNode1, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("3ced93917e658d10e2d9009470dad72b63c898d173721194a12f2ae5e190"), // ce573ced93917e658d10e2d9009470dad72b63c898d173721194a12f2ae5e190
 		block3MovedPremineAccount1,
 	})
 	block3MovedPremineLeafNodeHash1 = crypto.Keccak256(block3MovedPremineLeafNode1)
 	// path 0c0e050708
 	block3MovedPremineBalance2, _ = new(big.Int).SetString("1999944000000000000000", 10)
-	block3MovedPremineAccount2, _ = rlp.EncodeToBytes(types.StateAccount{
+	block3MovedPremineAccount2, _ = rlp.EncodeToBytes(&types.StateAccount{
 		Nonce:    0,
 		Balance:  block3MovedPremineBalance2,
 		CodeHash: test_helpers.NullCodeHash.Bytes(),
 		Root:     test_helpers.EmptyContractRoot,
 	})
-	block3MovedPremineLeafNode2, _ = rlp.EncodeToBytes([]interface{}{
+	block3MovedPremineLeafNode2, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("33bc1e69eedf90f402e11f6862da14ed8e50156635a04d6393bbae154012"), // ce5783bc1e69eedf90f402e11f6862da14ed8e50156635a04d6393bbae154012
 		block3MovedPremineAccount2,
 	})
 	block3MovedPremineLeafNodeHash2 = crypto.Keccak256(block3MovedPremineLeafNode2)
 
-	block3x0c0e0507BranchNode, _ = rlp.EncodeToBytes([]interface{}{
+	block3x0c0e0507BranchNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		[]byte{},
 		[]byte{},
 		[]byte{},
@@ -287,7 +287,7 @@ var (
 	})
 	block3x0c0e0507BranchNodeHash = crypto.Keccak256(block3x0c0e0507BranchNode)
 
-	block3x0c0e05BranchNode, _ = rlp.EncodeToBytes([]interface{}{
+	block3x0c0e05BranchNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("452e3beb503b1d87ae7c672b98a8e3fd043a671405502562ae1043dc97151a50"),
 		[]byte{},
 		common.Hex2Bytes("2f5bb16f77086f67ce8c4258cb9061cb299e597b2ad4ad6d7ccc474d6d88e85e"),
@@ -308,7 +308,7 @@ var (
 	})
 	block3x0c0e05BranchNodeHash = crypto.Keccak256(block3x0c0e05BranchNode)
 
-	block3x060eBranchNode, _ = rlp.EncodeToBytes([]interface{}{
+	block3x060eBranchNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("94d77c7c30b88829c9989948b206cda5e532b38b49534261c517aebf4a3e6fdb"),
 		common.Hex2Bytes("a5cf57a50da8204964e834a12a53f9bed7afc9b700a4a81b440122d60c7603a7"),
 		[]byte{},
@@ -329,7 +329,7 @@ var (
 	})
 	block3x060eBranchNodeHash = crypto.Keccak256(block3x060eBranchNode)
 
-	block3x0c0eBranchNode, _ = rlp.EncodeToBytes([]interface{}{
+	block3x0c0eBranchNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("70647f11b2b995d718f9e8aceb44c8839e0055641930d216fa6090280a9d63d5"),
 		common.Hex2Bytes("fdfb17cd2fba2a14219981cb7886a1977cd85dbef5c767c562f4a5f547febff0"),
 		common.Hex2Bytes("ff87313253ec6f860142b7bf62efb4cb07ea668c57aa90cbe9ef22b72fee15c7"),
@@ -350,7 +350,7 @@ var (
 	})
 	block3x0c0eBranchNodeHash = crypto.Keccak256(block3x0c0eBranchNode)
 
-	block3x06BranchNode, _ = rlp.EncodeToBytes([]interface{}{
+	block3x06BranchNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("68f7ff8c074d6e4cccd55b5b1c2116a6dd7047d4332090e6db8839362991b0ae"),
 		common.Hex2Bytes("c446eb4377c750701374c56e50759e6ba68b7adf4d543e718c8b28a99ae3b6ad"),
 		common.Hex2Bytes("ef2c49ec64cb65eae0d99684e74c8af2bd0206c9a0214d9d3eddf0881dd8412a"),
@@ -371,7 +371,7 @@ var (
 	})
 	block3x06BranchNodeHash = crypto.Keccak256(block3x06BranchNode)
 
-	block3x0cBranchNode, _ = rlp.EncodeToBytes([]interface{}{
+	block3x0cBranchNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("dae48f5b47930c28bb116fbd55e52cd47242c71bf55373b55eb2805ee2e4a929"),
 		common.Hex2Bytes("0f1f37f337ec800e2e5974e2e7355f10f1a4832b39b846d916c3597a460e0676"),
 		common.Hex2Bytes("da8f627bb8fbeead17b318e0a8e4f528db310f591bb6ab2deda4a9f7ca902ab5"),
@@ -392,7 +392,7 @@ var (
 	})
 	block3x0cBranchNodeHash = crypto.Keccak256(block3x0cBranchNode)
 
-	block3RootBranchNode, _ = rlp.EncodeToBytes([]interface{}{
+	block3RootBranchNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("f646da473c426e79f1c796b00d4873f47de1dbe1c9d19d63993a05eeb8b4041d"),
 		common.Hex2Bytes("babe369f6b12092f49181ae04ca173fb68d1a5456f18d20fa32cba73954052bd"),
 		common.Hex2Bytes("473ecf8a7e36a829e75039a3b055e51b8332cbf03324ab4af2066bbd6fbf0021"),
@@ -420,7 +420,7 @@ func init() {
 	}
 	db = rawdb.NewMemoryDatabase()
 	genesisBlock = core.DefaultGenesisBlock().MustCommit(db)
-	genBy, err := rlp.EncodeToBytes(genesisBlock)
+	genBy, err := rlp.EncodeToBytes(&genesisBlock)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -671,11 +671,11 @@ func TestBuilderOnMainnetBlocks(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		receivedStateDiffRlp, err := rlp.EncodeToBytes(diff)
+		receivedStateDiffRlp, err := rlp.EncodeToBytes(&diff)
 		if err != nil {
 			t.Error(err)
 		}
-		expectedStateDiffRlp, err := rlp.EncodeToBytes(test.expected)
+		expectedStateDiffRlp, err := rlp.EncodeToBytes(&test.expected)
 		if err != nil {
 			t.Error(err)
 		}

--- a/statediff/service.go
+++ b/statediff/service.go
@@ -516,7 +516,7 @@ func (sds *Service) processStateDiff(currentBlock *types.Block, parentRoot commo
 	if err != nil {
 		return nil, err
 	}
-	stateDiffRlp, err := rlp.EncodeToBytes(stateDiff)
+	stateDiffRlp, err := rlp.EncodeToBytes(&stateDiff)
 	if err != nil {
 		return nil, err
 	}
@@ -566,7 +566,7 @@ func (sds *Service) processStateTrie(block *types.Block, params Params) (*Payloa
 	if err != nil {
 		return nil, err
 	}
-	stateTrieRlp, err := rlp.EncodeToBytes(stateNodes)
+	stateTrieRlp, err := rlp.EncodeToBytes(&stateNodes)
 	if err != nil {
 		return nil, err
 	}
@@ -585,7 +585,7 @@ func (sds *Service) Subscribe(id rpc.ID, sub chan<- Payload, quitChan chan<- boo
 	params.ComputeWatchedAddressesLeafKeys()
 
 	// Subscription type is defined as the hash of the rlp-serialized subscription params
-	by, err := rlp.EncodeToBytes(params)
+	by, err := rlp.EncodeToBytes(&params)
 	if err != nil {
 		log.Error("State diffing params need to be rlp-serializable")
 		return

--- a/statediff/service_test.go
+++ b/statediff/service_test.go
@@ -235,7 +235,7 @@ func testErrorInStateDiffAt(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	expectedBlockRlp, err := rlp.EncodeToBytes(&testBlock1)
+	expectedBlockRlp, err := rlp.EncodeToBytes(testBlock1)
 	if err != nil {
 		t.Error(err)
 	}
@@ -269,7 +269,7 @@ func testErrorInStateDiffAt(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	stateDiffPayloadRlp, err := rlp.EncodeToBytes(&stateDiffPayload)
+	stateDiffPayloadRlp, err := rlp.EncodeToBytes(stateDiffPayload)
 	if err != nil {
 		t.Error(err)
 	}

--- a/statediff/service_test.go
+++ b/statediff/service_test.go
@@ -130,11 +130,11 @@ func testErrorInChainEventLoop(t *testing.T) {
 		t.Logf("Actual number of payloads does not equal expected.\nactual: %+v\nexpected: 3", len(payloads))
 	}
 
-	testReceipts1Rlp, err := rlp.EncodeToBytes(testReceipts1)
+	testReceipts1Rlp, err := rlp.EncodeToBytes(&testReceipts1)
 	if err != nil {
 		t.Error(err)
 	}
-	testReceipts2Rlp, err := rlp.EncodeToBytes(testReceipts2)
+	testReceipts2Rlp, err := rlp.EncodeToBytes(&testReceipts2)
 	if err != nil {
 		t.Error(err)
 	}
@@ -227,15 +227,15 @@ func testErrorInStateDiffAt(t *testing.T) {
 		BlockNumber: testBlock1.Number(),
 		BlockHash:   testBlock1.Hash(),
 	}
-	expectedStateDiffRlp, err := rlp.EncodeToBytes(mockStateDiff)
+	expectedStateDiffRlp, err := rlp.EncodeToBytes(&mockStateDiff)
 	if err != nil {
 		t.Error(err)
 	}
-	expectedReceiptsRlp, err := rlp.EncodeToBytes(testReceipts1)
+	expectedReceiptsRlp, err := rlp.EncodeToBytes(&testReceipts1)
 	if err != nil {
 		t.Error(err)
 	}
-	expectedBlockRlp, err := rlp.EncodeToBytes(testBlock1)
+	expectedBlockRlp, err := rlp.EncodeToBytes(&testBlock1)
 	if err != nil {
 		t.Error(err)
 	}
@@ -244,7 +244,7 @@ func testErrorInStateDiffAt(t *testing.T) {
 		ReceiptsRlp:    expectedReceiptsRlp,
 		BlockRlp:       expectedBlockRlp,
 	}
-	expectedStateDiffPayloadRlp, err := rlp.EncodeToBytes(expectedStateDiffPayload)
+	expectedStateDiffPayloadRlp, err := rlp.EncodeToBytes(&expectedStateDiffPayload)
 	if err != nil {
 		t.Error(err)
 	}
@@ -269,7 +269,7 @@ func testErrorInStateDiffAt(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	stateDiffPayloadRlp, err := rlp.EncodeToBytes(stateDiffPayload)
+	stateDiffPayloadRlp, err := rlp.EncodeToBytes(&stateDiffPayload)
 	if err != nil {
 		t.Error(err)
 	}

--- a/statediff/test_helpers/mocks/service.go
+++ b/statediff/test_helpers/mocks/service.go
@@ -156,7 +156,7 @@ func (sds *MockStateDiffService) processStateDiff(currentBlock *types.Block, par
 	if err != nil {
 		return nil, err
 	}
-	stateDiffRlp, err := rlp.EncodeToBytes(stateDiff)
+	stateDiffRlp, err := rlp.EncodeToBytes(&stateDiff)
 	if err != nil {
 		return nil, err
 	}
@@ -237,7 +237,7 @@ func (sds *MockStateDiffService) stateTrieAt(block *types.Block, params statedif
 	if err != nil {
 		return nil, err
 	}
-	stateTrieRlp, err := rlp.EncodeToBytes(stateNodes)
+	stateTrieRlp, err := rlp.EncodeToBytes(&stateNodes)
 	if err != nil {
 		return nil, err
 	}
@@ -247,7 +247,7 @@ func (sds *MockStateDiffService) stateTrieAt(block *types.Block, params statedif
 // Subscribe is used by the API to subscribe to the service loop
 func (sds *MockStateDiffService) Subscribe(id rpc.ID, sub chan<- statediff.Payload, quitChan chan<- bool, params statediff.Params) {
 	// Subscription type is defined as the hash of the rlp-serialized subscription params
-	by, err := rlp.EncodeToBytes(params)
+	by, err := rlp.EncodeToBytes(&params)
 	if err != nil {
 		return
 	}

--- a/statediff/test_helpers/mocks/service_test.go
+++ b/statediff/test_helpers/mocks/service_test.go
@@ -97,7 +97,7 @@ func testSubscriptionAPI(t *testing.T) {
 	defer chain.Stop()
 	block0 = test_helpers.Genesis
 	block1 = blocks[0]
-	expectedBlockRlp, _ := rlp.EncodeToBytes(&block1)
+	expectedBlockRlp, _ := rlp.EncodeToBytes(block1)
 	mockReceipt := &types.Receipt{
 		BlockNumber: block1.Number(),
 		BlockHash:   block1.Hash(),
@@ -189,7 +189,7 @@ func testHTTPAPI(t *testing.T) {
 	defer chain.Stop()
 	block0 = test_helpers.Genesis
 	block1 = blocks[0]
-	expectedBlockRlp, _ := rlp.EncodeToBytes(&block1)
+	expectedBlockRlp, _ := rlp.EncodeToBytes(block1)
 	mockReceipt := &types.Receipt{
 		BlockNumber: block1.Number(),
 		BlockHash:   block1.Hash(),

--- a/statediff/test_helpers/mocks/service_test.go
+++ b/statediff/test_helpers/mocks/service_test.go
@@ -40,33 +40,33 @@ var (
 	emptyStorage   = make([]sdtypes.StorageNode, 0)
 	block0, block1 *types.Block
 	minerLeafKey   = test_helpers.AddressToLeafKey(common.HexToAddress("0x0"))
-	account1, _    = rlp.EncodeToBytes(types.StateAccount{
+	account1, _    = rlp.EncodeToBytes(&types.StateAccount{
 		Nonce:    uint64(0),
 		Balance:  big.NewInt(10000),
 		CodeHash: common.HexToHash("0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470").Bytes(),
 		Root:     common.HexToHash("0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"),
 	})
-	account1LeafNode, _ = rlp.EncodeToBytes([]interface{}{
+	account1LeafNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("3926db69aaced518e9b9f0f434a473e7174109c943548bb8f23be41ca76d9ad2"),
 		account1,
 	})
-	minerAccount, _ = rlp.EncodeToBytes(types.StateAccount{
+	minerAccount, _ = rlp.EncodeToBytes(&types.StateAccount{
 		Nonce:    uint64(0),
 		Balance:  big.NewInt(2000002625000000000),
 		CodeHash: common.HexToHash("0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470").Bytes(),
 		Root:     common.HexToHash("0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"),
 	})
-	minerAccountLeafNode, _ = rlp.EncodeToBytes([]interface{}{
+	minerAccountLeafNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("3380c7b7ae81a58eb98d9c78de4a1fd7fd9535fc953ed2be602daaa41767312a"),
 		minerAccount,
 	})
-	bankAccount, _ = rlp.EncodeToBytes(types.StateAccount{
+	bankAccount, _ = rlp.EncodeToBytes(&types.StateAccount{
 		Nonce:    uint64(1),
 		Balance:  big.NewInt(1999978999999990000),
 		CodeHash: common.HexToHash("0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470").Bytes(),
 		Root:     common.HexToHash("0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"),
 	})
-	bankAccountLeafNode, _ = rlp.EncodeToBytes([]interface{}{
+	bankAccountLeafNode, _ = rlp.EncodeToBytes(&[]interface{}{
 		common.Hex2Bytes("30bf49f440a1cd0527e4d06e2765654c0f56452257516d793a9b8d604dcfdf2a"),
 		bankAccount,
 	})
@@ -97,12 +97,12 @@ func testSubscriptionAPI(t *testing.T) {
 	defer chain.Stop()
 	block0 = test_helpers.Genesis
 	block1 = blocks[0]
-	expectedBlockRlp, _ := rlp.EncodeToBytes(block1)
+	expectedBlockRlp, _ := rlp.EncodeToBytes(&block1)
 	mockReceipt := &types.Receipt{
 		BlockNumber: block1.Number(),
 		BlockHash:   block1.Hash(),
 	}
-	expectedReceiptBytes, _ := rlp.EncodeToBytes(types.Receipts{mockReceipt})
+	expectedReceiptBytes, _ := rlp.EncodeToBytes(&types.Receipts{mockReceipt})
 	expectedStateDiff := sdtypes.StateObject{
 		BlockNumber: block1.Number(),
 		BlockHash:   block1.Hash(),
@@ -130,7 +130,7 @@ func testSubscriptionAPI(t *testing.T) {
 			},
 		},
 	}
-	expectedStateDiffBytes, _ := rlp.EncodeToBytes(expectedStateDiff)
+	expectedStateDiffBytes, _ := rlp.EncodeToBytes(&expectedStateDiff)
 
 	blockChan := make(chan *types.Block)
 	parentBlockChain := make(chan *types.Block)
@@ -189,12 +189,12 @@ func testHTTPAPI(t *testing.T) {
 	defer chain.Stop()
 	block0 = test_helpers.Genesis
 	block1 = blocks[0]
-	expectedBlockRlp, _ := rlp.EncodeToBytes(block1)
+	expectedBlockRlp, _ := rlp.EncodeToBytes(&block1)
 	mockReceipt := &types.Receipt{
 		BlockNumber: block1.Number(),
 		BlockHash:   block1.Hash(),
 	}
-	expectedReceiptBytes, _ := rlp.EncodeToBytes(types.Receipts{mockReceipt})
+	expectedReceiptBytes, _ := rlp.EncodeToBytes(&types.Receipts{mockReceipt})
 	expectedStateDiff := sdtypes.StateObject{
 		BlockNumber: block1.Number(),
 		BlockHash:   block1.Hash(),
@@ -222,7 +222,7 @@ func testHTTPAPI(t *testing.T) {
 			},
 		},
 	}
-	expectedStateDiffBytes, _ := rlp.EncodeToBytes(expectedStateDiff)
+	expectedStateDiffBytes, _ := rlp.EncodeToBytes(&expectedStateDiff)
 	mockBlockChain := &BlockChain{}
 	mockBlockChain.SetBlocksForHashes(map[common.Hash]*types.Block{
 		block0.Hash(): block0,

--- a/statediff/test_helpers/test_data.go
+++ b/statediff/test_helpers/test_data.go
@@ -69,6 +69,6 @@ var (
 	CodeHash                = common.HexToHash("0xaaea5efba4fd7b45d7ec03918ac5d8b31aa93b48986af0e6b591f0f087c80127")
 	ContractAddr            common.Address
 
-	EmptyRootNode, _  = rlp.EncodeToBytes([]byte{})
+	EmptyRootNode, _  = rlp.EncodeToBytes(&[]byte{})
 	EmptyContractRoot = crypto.Keccak256Hash(EmptyRootNode)
 )


### PR DESCRIPTION
The major change to integrate the patch has been:

* Updating the arguments for `rlp.EncodeToBytes`. This function accepts interfaces, but since the last update, it is better to pass in a pointer to the function.
* From the Ethereum Release Notes: *"Compatibility note about `core/types`: For optimization purposes, `types.Header` and other types in this package now implement the `rlp.Encoder` interface. This change can cause incompatibilities because the new method is implemented with pointer receiver. Attempting to RLP-encode unadressable (i.e. non-pointer) values of type `Header` does not work anymore and will result in an error."*
* Instead of just updating all the headers. I have updated all parameters for the `rlp.EncodeToBytes` to be pointers instead of values.

__Please take a close look at the updates__. The functions won't fail if a non-pointer is passed (in most cases), but we could be unexpected behaviors.