### PR TITLE
Update known gaps condition to allow single block gaps.

### DIFF
--- a/statediff/known_gaps.go
+++ b/statediff/known_gaps.go
@@ -100,7 +100,7 @@ func minMax(array []*big.Int) (*big.Int, *big.Int) {
 // 3. Write to prometheus directly.
 // 4. Logs and error.
 func (kg *KnownGapsState) pushKnownGaps(startingBlockNumber *big.Int, endingBlockNumber *big.Int, checkedOut bool, processingKey int64) error {
-	if startingBlockNumber.Cmp(endingBlockNumber) != -1 {
+	if startingBlockNumber.Cmp(endingBlockNumber) == 1 {
 		return fmt.Errorf("Starting Block %d, is greater than ending block %d", startingBlockNumber, endingBlockNumber)
 	}
 	knownGap := models.KnownGapsModel{


### PR DESCRIPTION
Currently, if the knownGaps is a single block, this condition will not allow it to be entered in the DB. We only want to capture errors where the end block is greater than the start block. The end block and start block can be the same.