### PR TITLE
[WIP] Index intermediate nodes for watched addresses and refactor builder code

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,8 +4,8 @@ on:
   workflow_call:
 
 env:
-  stack-orchestrator-ref: ${{ github.event.inputs.stack-orchestrator-ref  || 'feature/geth-testing'}}
-  ipld-eth-db-ref: ${{ github.event.inputs.ipld-ethcl-db-ref  || 'feature/startup-script' }}
+  stack-orchestrator-ref: "382aca8e42bc5e33f301f77cdd2e09cc80602fc3"
+  ipld-eth-db-ref: "48eb594ea95763bda8e51590f105f7a2657ac6d4"
   GOPATH: /tmp/go
 
 jobs:
@@ -70,20 +70,14 @@ jobs:
       - name: Create config file
         run: |
           echo vulcanize_ipld_eth_db=$GITHUB_WORKSPACE/ipld-eth-db/ > $GITHUB_WORKSPACE/config.sh
-          echo vulcanize_go_ethereum=$GITHUB_WORKSPACE/go-ethereum/ >> $GITHUB_WORKSPACE/config.sh
-          echo db_write=true >> $GITHUB_WORKSPACE/config.sh
           cat $GITHUB_WORKSPACE/config.sh
 
       - name: Run docker compose
         run: |
           docker-compose  \
-          -f "$GITHUB_WORKSPACE/stack-orchestrator/docker/local/docker-compose-db-migration.yml" \
-          -f "$GITHUB_WORKSPACE/stack-orchestrator/docker/latest/docker-compose-timescale-db.yml" \
+          -f "$GITHUB_WORKSPACE/stack-orchestrator/docker/local/docker-compose-db-sharding.yml" \
           --env-file $GITHUB_WORKSPACE/config.sh \
           up -d --build
-
-      - name: Give the migration a few seconds
-        run: sleep 30;
 
       - name: Run unit tests
         run: make statedifftest
@@ -135,9 +129,8 @@ jobs:
       - name: Run docker compose
         run: |
           docker-compose  \
-          -f "$GITHUB_WORKSPACE/stack-orchestrator/docker/local/docker-compose-db-migration.yml" \
-          -f "$GITHUB_WORKSPACE/stack-orchestrator/docker/local/docker-compose-go-ethereum4.yml" \
-          -f "$GITHUB_WORKSPACE/stack-orchestrator/docker/latest/docker-compose-timescale-db.yml" \
+          -f "$GITHUB_WORKSPACE/stack-orchestrator/docker/local/docker-compose-db-sharding.yml" \
+          -f "$GITHUB_WORKSPACE/stack-orchestrator/docker/local/docker-compose-go-ethereum.yml" \
           --env-file $GITHUB_WORKSPACE/config.sh \
           up -d --build
 
@@ -160,7 +153,7 @@ jobs:
       - name: Make sure we see entries in the header table
         shell: bash
         run: |
-          rows=$(docker compose -f "$GITHUB_WORKSPACE/stack-orchestrator/docker/local/docker-compose-go-ethereum.yml" exec access-node psql -U vdbm -d vulcanize_testing_v4  -AXqtc "SELECT COUNT(*) FROM eth.header_cids")
+          rows=$(docker compose -f "$GITHUB_WORKSPACE/stack-orchestrator/docker/local/docker-compose-go-ethereum.yml" exec ipld-eth-db psql -U vdbm -d vulcanize_testing  -AXqtc "SELECT COUNT(*) FROM eth.header_cids")
           [[ "$rows" -lt "1" ]] && echo "We could not find any rows in postgres table." && (exit 1)
           echo $rows
-          docker compose -f "$GITHUB_WORKSPACE/stack-orchestrator/docker/local/docker-compose-go-ethereum.yml" exec access-node psql -U vdbm -d vulcanize_testing_v4  -AXqtc "SELECT * FROM eth.header_cids"
+          docker compose -f "$GITHUB_WORKSPACE/stack-orchestrator/docker/local/docker-compose-go-ethereum.yml" exec ipld-eth-db psql -U vdbm -d vulcanize_testing  -AXqtc "SELECT * FROM eth.header_cids"

--- a/go.mod
+++ b/go.mod
@@ -61,6 +61,7 @@ require (
 	github.com/multiformats/go-multihash v0.0.14
 	github.com/naoina/go-stringutil v0.1.0 // indirect
 	github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416
+	github.com/oleiade/lane v1.0.1
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/peterh/liner v1.1.1-0.20190123174540-a2c9a5303de7
 	github.com/pganalyze/pg_query_go/v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -483,6 +483,8 @@ github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416/go.mod h1:NBIhNtsFMo
 github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
+github.com/oleiade/lane v1.0.1 h1:hXofkn7GEOubzTwNpeL9MaNy8WxolCYb9cInAIeqShU=
+github.com/oleiade/lane v1.0.1/go.mod h1:IyTkraa4maLfjq/GmHR+Dxb4kCMtEGeb+qmhlrQ5Mk4=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/statediff/builder.go
+++ b/statediff/builder.go
@@ -452,7 +452,9 @@ func (sdb *builder) deletedOrUpdatedState(a, b trie.NodeIterator, diffAccountsAt
 			}
 		case types2.Extension, types2.Branch:
 			// process nodes from intermediateNodeStack
-			intermediateNodeStack, err = processDeletedOrUpdatedIntermediateNodes(intermediateNodeStack, node, it.Hash(), it.Parent(), diffPathsAtB, output)
+			if shouldIndexIntermediateStateNodes {
+				intermediateNodeStack, err = processDeletedOrUpdatedIntermediateNodes(intermediateNodeStack, node, it.Hash(), it.Parent(), diffPathsAtB, output)
+			}
 
 			// fall through, we did everything we need to do with these node types
 		default:

--- a/statediff/builder_test.go
+++ b/statediff/builder_test.go
@@ -1001,7 +1001,9 @@ func TestBuilderWithWatchedAddressList(t *testing.T) {
 	block2 = blocks[1]
 	block3 = blocks[2]
 	params := statediff.Params{
-		WatchedAddresses: []common.Address{test_helpers.Account1Addr, test_helpers.ContractAddr},
+		IntermediateStateNodes:   true,
+		IntermediateStorageNodes: true,
+		WatchedAddresses:         []common.Address{test_helpers.Account1Addr, test_helpers.ContractAddr},
 	}
 	params.ComputeWatchedAddressesLeafKeys()
 	builder = statediff.NewBuilder(chain.StateCache())
@@ -1054,6 +1056,12 @@ func TestBuilderWithWatchedAddressList(t *testing.T) {
 				BlockHash:   block1.Hash(),
 				Nodes: []types2.StateNode{
 					{
+						Path:         []byte{},
+						NodeType:     types2.Branch,
+						NodeValue:    block1BranchRootNode,
+						StorageNodes: emptyStorage,
+					},
+					{
 						Path:         []byte{'\x0e'},
 						NodeType:     types2.Leaf,
 						LeafKey:      test_helpers.Account1LeafKey,
@@ -1078,11 +1086,22 @@ func TestBuilderWithWatchedAddressList(t *testing.T) {
 				BlockHash:   block2.Hash(),
 				Nodes: []types2.StateNode{
 					{
+						Path:         []byte{},
+						NodeType:     types2.Branch,
+						NodeValue:    block2BranchRootNode,
+						StorageNodes: emptyStorage,
+					},
+					{
 						Path:      []byte{'\x06'},
 						NodeType:  types2.Leaf,
 						LeafKey:   contractLeafKey,
 						NodeValue: contractAccountAtBlock2LeafNode,
 						StorageNodes: []types2.StorageNode{
+							{
+								Path:      []byte{},
+								NodeType:  types2.Branch,
+								NodeValue: block2StorageBranchRootNode,
+							},
 							{
 								Path:      []byte{'\x02'},
 								NodeType:  types2.Leaf,
@@ -1128,11 +1147,22 @@ func TestBuilderWithWatchedAddressList(t *testing.T) {
 				BlockHash:   block3.Hash(),
 				Nodes: []types2.StateNode{
 					{
+						Path:         []byte{},
+						NodeType:     types2.Branch,
+						NodeValue:    block3BranchRootNode,
+						StorageNodes: emptyStorage,
+					},
+					{
 						Path:      []byte{'\x06'},
 						NodeType:  types2.Leaf,
 						LeafKey:   contractLeafKey,
 						NodeValue: contractAccountAtBlock3LeafNode,
 						StorageNodes: []types2.StorageNode{
+							{
+								Path:      []byte{},
+								NodeType:  types2.Branch,
+								NodeValue: block3StorageBranchRootNode,
+							},
 							{
 								Path:      []byte{'\x0c'},
 								NodeType:  types2.Leaf,
@@ -1606,7 +1636,9 @@ func TestBuilderWithRemovedNonWatchedAccount(t *testing.T) {
 	block5 = blocks[4]
 	block6 = blocks[5]
 	params := statediff.Params{
-		WatchedAddresses: []common.Address{test_helpers.Account1Addr, test_helpers.Account2Addr},
+		IntermediateStateNodes:   true,
+		IntermediateStorageNodes: true,
+		WatchedAddresses:         []common.Address{test_helpers.Account1Addr, test_helpers.Account2Addr},
 	}
 	params.ComputeWatchedAddressesLeafKeys()
 	builder = statediff.NewBuilder(chain.StateCache())
@@ -1628,6 +1660,12 @@ func TestBuilderWithRemovedNonWatchedAccount(t *testing.T) {
 				BlockNumber: block4.Number(),
 				BlockHash:   block4.Hash(),
 				Nodes: []types2.StateNode{
+					{
+						Path:         []byte{},
+						NodeType:     types2.Branch,
+						NodeValue:    block4BranchRootNode,
+						StorageNodes: emptyStorage,
+					},
 					{
 						Path:         []byte{'\x0c'},
 						NodeType:     types2.Leaf,
@@ -1651,6 +1689,12 @@ func TestBuilderWithRemovedNonWatchedAccount(t *testing.T) {
 				BlockHash:   block5.Hash(),
 				Nodes: []types2.StateNode{
 					{
+						Path:         []byte{},
+						NodeType:     types2.Branch,
+						NodeValue:    block5BranchRootNode,
+						StorageNodes: emptyStorage,
+					},
+					{
 						Path:         []byte{'\x0e'},
 						NodeType:     types2.Leaf,
 						LeafKey:      test_helpers.Account1LeafKey,
@@ -1672,6 +1716,12 @@ func TestBuilderWithRemovedNonWatchedAccount(t *testing.T) {
 				BlockNumber: block6.Number(),
 				BlockHash:   block6.Hash(),
 				Nodes: []types2.StateNode{
+					{
+						Path:         []byte{},
+						NodeType:     types2.Branch,
+						NodeValue:    block6BranchRootNode,
+						StorageNodes: emptyStorage,
+					},
 					{
 						Path:         []byte{'\x0c'},
 						NodeType:     types2.Leaf,
@@ -1724,7 +1774,9 @@ func TestBuilderWithRemovedWatchedAccount(t *testing.T) {
 	block5 = blocks[4]
 	block6 = blocks[5]
 	params := statediff.Params{
-		WatchedAddresses: []common.Address{test_helpers.Account1Addr, test_helpers.ContractAddr},
+		IntermediateStateNodes:   true,
+		IntermediateStorageNodes: true,
+		WatchedAddresses:         []common.Address{test_helpers.Account1Addr, test_helpers.ContractAddr},
 	}
 	params.ComputeWatchedAddressesLeafKeys()
 	builder = statediff.NewBuilder(chain.StateCache())
@@ -1747,11 +1799,22 @@ func TestBuilderWithRemovedWatchedAccount(t *testing.T) {
 				BlockHash:   block4.Hash(),
 				Nodes: []types2.StateNode{
 					{
+						Path:         []byte{},
+						NodeType:     types2.Branch,
+						NodeValue:    block4BranchRootNode,
+						StorageNodes: emptyStorage,
+					},
+					{
 						Path:      []byte{'\x06'},
 						NodeType:  types2.Leaf,
 						LeafKey:   contractLeafKey,
 						NodeValue: contractAccountAtBlock4LeafNode,
 						StorageNodes: []types2.StorageNode{
+							{
+								Path:      []byte{},
+								NodeType:  types2.Branch,
+								NodeValue: block4StorageBranchRootNode,
+							},
 							{
 								Path:      []byte{'\x04'},
 								NodeType:  types2.Leaf,
@@ -1788,11 +1851,22 @@ func TestBuilderWithRemovedWatchedAccount(t *testing.T) {
 				BlockHash:   block5.Hash(),
 				Nodes: []types2.StateNode{
 					{
+						Path:         []byte{},
+						NodeType:     types2.Branch,
+						NodeValue:    block5BranchRootNode,
+						StorageNodes: emptyStorage,
+					},
+					{
 						Path:      []byte{'\x06'},
 						NodeType:  types2.Leaf,
 						LeafKey:   contractLeafKey,
 						NodeValue: contractAccountAtBlock5LeafNode,
 						StorageNodes: []types2.StorageNode{
+							{
+								Path:      []byte{},
+								NodeType:  types2.Branch,
+								NodeValue: block5StorageBranchRootNode,
+							},
 							{
 								Path:      []byte{'\x0c'},
 								NodeType:  types2.Leaf,
@@ -1830,11 +1904,22 @@ func TestBuilderWithRemovedWatchedAccount(t *testing.T) {
 				BlockHash:   block6.Hash(),
 				Nodes: []types2.StateNode{
 					{
+						Path:         []byte{},
+						NodeType:     types2.Branch,
+						NodeValue:    block6BranchRootNode,
+						StorageNodes: emptyStorage,
+					},
+					{
 						Path:      []byte{'\x06'},
 						NodeType:  types2.Removed,
 						LeafKey:   contractLeafKey,
 						NodeValue: []byte{},
 						StorageNodes: []types2.StorageNode{
+							{
+								Path:      []byte{},
+								NodeType:  types2.Removed,
+								NodeValue: []byte{},
+							},
 							{
 								Path:      []byte{'\x02'},
 								NodeType:  types2.Removed,

--- a/statediff/indexer/database/sql/postgres/config.go
+++ b/statediff/indexer/database/sql/postgres/config.go
@@ -48,8 +48,8 @@ func ResolveDriverType(str string) (DriverType, error) {
 // DefaultConfig are default parameters for connecting to a Postgres sql
 var DefaultConfig = Config{
 	Hostname:     "localhost",
-	Port:         8066,
-	DatabaseName: "vulcanize_testing_v4",
+	Port:         8077,
+	DatabaseName: "vulcanize_testing",
 	Username:     "vdbm",
 	Password:     "password",
 }


### PR DESCRIPTION
Part of https://github.com/vulcanize/go-ethereum/issues/29

- Index intermediate nodes on path to leaf nodes for watched addresses using a stack as suggested in https://github.com/vulcanize/go-ethereum/issues/29#issuecomment-1149086538
- The intermediate nodes are indexed directly if the watched addresses list is empty
- Changes to reuse builder code in `eth-statediff-service`