### PR TITLE
Disassociate block number from the indexer object

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   stack-orchestrator-ref: ${{ github.event.inputs.stack-orchestrator-ref  || '382aca8e42bc5e33f301f77cdd2e09cc80602fc3'}}
-  ipld-eth-db-ref: ${{ github.event.inputs.ipld-ethcl-db-ref  || '48eb594ea95763bda8e51590f105f7a2657ac6d4' }}
+  ipld-eth-db-ref: ${{ github.event.inputs.ipld-ethcl-db-ref  || '65b7bee7a6757c1fc527c8bfdc4f99ab915fcf36' }}
   GOPATH: /tmp/go
 
 jobs:

--- a/statediff/indexer/database/dump/batch_tx.go
+++ b/statediff/indexer/database/dump/batch_tx.go
@@ -30,7 +30,7 @@ import (
 
 // BatchTx wraps a void with the state necessary for building the tx concurrently during trie difference iteration
 type BatchTx struct {
-	BlockNumber uint64
+	BlockNumber string
 	dump        io.Writer
 	quit        chan struct{}
 	iplds       chan models.IPLDModel
@@ -68,15 +68,17 @@ func (tx *BatchTx) cache() {
 
 func (tx *BatchTx) cacheDirect(key string, value []byte) {
 	tx.iplds <- models.IPLDModel{
-		Key:  key,
-		Data: value,
+		BlockNumber: tx.BlockNumber,
+		Key:         key,
+		Data:        value,
 	}
 }
 
 func (tx *BatchTx) cacheIPLD(i node.Node) {
 	tx.iplds <- models.IPLDModel{
-		Key:  blockstore.BlockPrefix.String() + dshelp.MultihashToDsKey(i.Cid().Hash()).String(),
-		Data: i.RawData(),
+		BlockNumber: tx.BlockNumber,
+		Key:         blockstore.BlockPrefix.String() + dshelp.MultihashToDsKey(i.Cid().Hash()).String(),
+		Data:        i.RawData(),
 	}
 }
 
@@ -87,8 +89,9 @@ func (tx *BatchTx) cacheRaw(codec, mh uint64, raw []byte) (string, string, error
 	}
 	prefixedKey := blockstore.BlockPrefix.String() + dshelp.MultihashToDsKey(c.Hash()).String()
 	tx.iplds <- models.IPLDModel{
-		Key:  prefixedKey,
-		Data: raw,
+		BlockNumber: tx.BlockNumber,
+		Key:         prefixedKey,
+		Data:        raw,
 	}
 	return c.String(), prefixedKey, err
 }


### PR DESCRIPTION
Fixes https://github.com/vulcanize/go-ethereum/issues/245

- Remove block number field from the indexer struct and instead pass as a function argument wherever required