### PR TITLE
Use watched addresses from direct indexing params by default while serving statediff APIs

### DIFF
--- a/statediff/service.go
+++ b/statediff/service.go
@@ -477,6 +477,13 @@ func (sds *Service) StateDiffAt(blockNumber uint64, params Params) (*Payload, er
 	currentBlock := sds.BlockChain.GetBlockByNumber(blockNumber)
 	log.Info("sending state diff", "block height", blockNumber)
 
+	// use watched addresses from statediffing write loop if not provided
+	if params.WatchedAddresses == nil {
+		writeLoopParams.RLock()
+		params.WatchedAddresses = make([]common.Address, len(writeLoopParams.WatchedAddresses))
+		copy(params.WatchedAddresses, writeLoopParams.WatchedAddresses)
+		writeLoopParams.RUnlock()
+	}
 	// compute leaf paths of watched addresses in the params
 	params.ComputeWatchedAddressesLeafPaths()
 
@@ -493,6 +500,13 @@ func (sds *Service) StateDiffFor(blockHash common.Hash, params Params) (*Payload
 	currentBlock := sds.BlockChain.GetBlockByHash(blockHash)
 	log.Info("sending state diff", "block hash", blockHash)
 
+	// use watched addresses from statediffing write loop if not provided
+	if params.WatchedAddresses == nil {
+		writeLoopParams.RLock()
+		params.WatchedAddresses = make([]common.Address, len(writeLoopParams.WatchedAddresses))
+		copy(params.WatchedAddresses, writeLoopParams.WatchedAddresses)
+		writeLoopParams.RUnlock()
+	}
 	// compute leaf paths of watched addresses in the params
 	params.ComputeWatchedAddressesLeafPaths()
 
@@ -777,6 +791,15 @@ func (sds *Service) StreamCodeAndCodeHash(blockNumber uint64, outChan chan<- typ
 // This operation cannot be performed back past the point of db pruning; it requires an archival node
 // for historical data
 func (sds *Service) WriteStateDiffAt(blockNumber uint64, params Params) error {
+	log.Info("writing state diff at", "block height", blockNumber)
+
+	// use watched addresses from statediffing write loop if not provided
+	if params.WatchedAddresses == nil {
+		writeLoopParams.RLock()
+		params.WatchedAddresses = make([]common.Address, len(writeLoopParams.WatchedAddresses))
+		copy(params.WatchedAddresses, writeLoopParams.WatchedAddresses)
+		writeLoopParams.RUnlock()
+	}
 	// compute leaf paths of watched addresses in the params
 	params.ComputeWatchedAddressesLeafPaths()
 
@@ -793,6 +816,15 @@ func (sds *Service) WriteStateDiffAt(blockNumber uint64, params Params) error {
 // This operation cannot be performed back past the point of db pruning; it requires an archival node
 // for historical data
 func (sds *Service) WriteStateDiffFor(blockHash common.Hash, params Params) error {
+	log.Info("writing state diff for", "block hash", blockHash)
+
+	// use watched addresses from statediffing write loop if not provided
+	if params.WatchedAddresses == nil {
+		writeLoopParams.RLock()
+		params.WatchedAddresses = make([]common.Address, len(writeLoopParams.WatchedAddresses))
+		copy(params.WatchedAddresses, writeLoopParams.WatchedAddresses)
+		writeLoopParams.RUnlock()
+	}
 	// compute leaf paths of watched addresses in the params
 	params.ComputeWatchedAddressesLeafPaths()
 

--- a/statediff/service.go
+++ b/statediff/service.go
@@ -483,7 +483,7 @@ func (sds *Service) StateDiffAt(blockNumber uint64, params Params) (*Payload, er
 	log.Info("sending state diff", "block height", blockNumber)
 
 	// use watched addresses from statediffing write loop if not provided
-	if params.WatchedAddresses == nil {
+	if params.WatchedAddresses == nil && writeLoopParams.WatchedAddresses != nil {
 		writeLoopParams.RLock()
 		params.WatchedAddresses = make([]common.Address, len(writeLoopParams.WatchedAddresses))
 		copy(params.WatchedAddresses, writeLoopParams.WatchedAddresses)
@@ -506,7 +506,7 @@ func (sds *Service) StateDiffFor(blockHash common.Hash, params Params) (*Payload
 	log.Info("sending state diff", "block hash", blockHash)
 
 	// use watched addresses from statediffing write loop if not provided
-	if params.WatchedAddresses == nil {
+	if params.WatchedAddresses == nil && writeLoopParams.WatchedAddresses != nil {
 		writeLoopParams.RLock()
 		params.WatchedAddresses = make([]common.Address, len(writeLoopParams.WatchedAddresses))
 		copy(params.WatchedAddresses, writeLoopParams.WatchedAddresses)
@@ -799,7 +799,7 @@ func (sds *Service) WriteStateDiffAt(blockNumber uint64, params Params) error {
 	log.Info("writing state diff at", "block height", blockNumber)
 
 	// use watched addresses from statediffing write loop if not provided
-	if params.WatchedAddresses == nil {
+	if params.WatchedAddresses == nil && writeLoopParams.WatchedAddresses != nil {
 		writeLoopParams.RLock()
 		params.WatchedAddresses = make([]common.Address, len(writeLoopParams.WatchedAddresses))
 		copy(params.WatchedAddresses, writeLoopParams.WatchedAddresses)
@@ -824,7 +824,7 @@ func (sds *Service) WriteStateDiffFor(blockHash common.Hash, params Params) erro
 	log.Info("writing state diff for", "block hash", blockHash)
 
 	// use watched addresses from statediffing write loop if not provided
-	if params.WatchedAddresses == nil {
+	if params.WatchedAddresses == nil && writeLoopParams.WatchedAddresses != nil {
 		writeLoopParams.RLock()
 		params.WatchedAddresses = make([]common.Address, len(writeLoopParams.WatchedAddresses))
 		copy(params.WatchedAddresses, writeLoopParams.WatchedAddresses)

--- a/statediff/service_test.go
+++ b/statediff/service_test.go
@@ -78,9 +78,10 @@ var (
 	event3 = core.ChainEvent{Block: testBlock3}
 
 	defaultParams = statediff.Params{
-		IncludeBlock:    true,
-		IncludeReceipts: true,
-		IncludeTD:       true,
+		IncludeBlock:     true,
+		IncludeReceipts:  true,
+		IncludeTD:        true,
+		WatchedAddresses: []common.Address{},
 	}
 )
 


### PR DESCRIPTION
Part of https://github.com/vulcanize/go-ethereum/issues/261

- Use watched addresses from direct indexing params when `WatchedAddresses` is not explicitly set in statediff API calls
- Avoid using indexer object when direct indexing is off
  (prevent `nil pointer dereference` error)