### PR TITLE
fix non-deterministic ordering in unit tests

### DIFF
--- a/statediff/indexer/database/sql/pgx_indexer_test.go
+++ b/statediff/indexer/database/sql/pgx_indexer_test.go
@@ -548,8 +548,12 @@ func TestPGXIndexer(t *testing.T) {
 			t.Fatal(err)
 		}
 		require.Equal(t, 3, len(storageNodes))
-		expectedStorageNodes := []models.StorageNodeWithStateKeyModel{
-			{
+		gotStorageNodes := make(map[string]models.StorageNodeWithStateKeyModel, 3)
+		for _, model := range storageNodes {
+			gotStorageNodes[model.StorageKey] = model
+		}
+		expectedStorageNodes := map[string]models.StorageNodeWithStateKeyModel{
+			common.BytesToHash(mocks.RemovedLeafKey).Hex(): {
 				BlockNumber: mocks.BlockNumber.String(),
 				CID:         shared.RemovedNodeStorageCID,
 				NodeType:    3,
@@ -557,7 +561,7 @@ func TestPGXIndexer(t *testing.T) {
 				StateKey:    common.BytesToHash(mocks.ContractLeafKey).Hex(),
 				Path:        []byte{'\x03'},
 			},
-			{
+			common.BytesToHash(mocks.Storage2LeafKey).Hex(): {
 				BlockNumber: mocks.BlockNumber.String(),
 				CID:         shared.RemovedNodeStorageCID,
 				NodeType:    3,
@@ -565,7 +569,7 @@ func TestPGXIndexer(t *testing.T) {
 				StateKey:    common.BytesToHash(mocks.Contract2LeafKey).Hex(),
 				Path:        []byte{'\x0e'},
 			},
-			{
+			common.BytesToHash(mocks.Storage3LeafKey).Hex(): {
 				BlockNumber: mocks.BlockNumber.String(),
 				CID:         shared.RemovedNodeStorageCID,
 				NodeType:    3,
@@ -574,8 +578,8 @@ func TestPGXIndexer(t *testing.T) {
 				Path:        []byte{'\x0f'},
 			},
 		}
-		for idx, storageNode := range storageNodes {
-			require.Equal(t, expectedStorageNodes[idx], storageNode)
+		for storageKey, storageNode := range gotStorageNodes {
+			require.Equal(t, expectedStorageNodes[storageKey], storageNode)
 			dc, err = cid.Decode(storageNode.CID)
 			if err != nil {
 				t.Fatal(err)

--- a/statediff/indexer/database/sql/sqlx_indexer_test.go
+++ b/statediff/indexer/database/sql/sqlx_indexer_test.go
@@ -541,8 +541,12 @@ func TestSQLXIndexer(t *testing.T) {
 			t.Fatal(err)
 		}
 		require.Equal(t, 3, len(storageNodes))
-		expectedStorageNodes := []models.StorageNodeWithStateKeyModel{
-			{
+		gotStorageNodes := make(map[string]models.StorageNodeWithStateKeyModel, 3)
+		for _, model := range storageNodes {
+			gotStorageNodes[model.StorageKey] = model
+		}
+		expectedStorageNodes := map[string]models.StorageNodeWithStateKeyModel{
+			common.BytesToHash(mocks.RemovedLeafKey).Hex(): {
 				BlockNumber: mocks.BlockNumber.String(),
 				CID:         shared.RemovedNodeStorageCID,
 				NodeType:    3,
@@ -550,7 +554,7 @@ func TestSQLXIndexer(t *testing.T) {
 				StateKey:    common.BytesToHash(mocks.ContractLeafKey).Hex(),
 				Path:        []byte{'\x03'},
 			},
-			{
+			common.BytesToHash(mocks.Storage2LeafKey).Hex(): {
 				BlockNumber: mocks.BlockNumber.String(),
 				CID:         shared.RemovedNodeStorageCID,
 				NodeType:    3,
@@ -558,7 +562,7 @@ func TestSQLXIndexer(t *testing.T) {
 				StateKey:    common.BytesToHash(mocks.Contract2LeafKey).Hex(),
 				Path:        []byte{'\x0e'},
 			},
-			{
+			common.BytesToHash(mocks.Storage3LeafKey).Hex(): {
 				BlockNumber: mocks.BlockNumber.String(),
 				CID:         shared.RemovedNodeStorageCID,
 				NodeType:    3,
@@ -567,8 +571,8 @@ func TestSQLXIndexer(t *testing.T) {
 				Path:        []byte{'\x0f'},
 			},
 		}
-		for idx, storageNode := range storageNodes {
-			require.Equal(t, expectedStorageNodes[idx], storageNode)
+		for storageKey, storageNode := range gotStorageNodes {
+			require.Equal(t, expectedStorageNodes[storageKey], storageNode)
 			dc, err = cid.Decode(storageNode.CID)
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
Noticed while working on v5, backporting here as it could cause random failures in CI/CD and confuse that work.