### PR TITLE
Implement delayed Tx

### DIFF
--- a/statediff/indexer/database/sql/indexer.go
+++ b/statediff/indexer/database/sql/indexer.go
@@ -122,11 +122,8 @@ func (sdi *StateDiffIndexer) PushBlock(block *types.Block, receipts types.Receip
 	}
 	t = time.Now()
 
-	// Begin new db tx for everything
-	tx, err := sdi.dbWriter.db.Begin(sdi.ctx)
-	if err != nil {
-		return nil, err
-	}
+	// Begin new DB tx for everything
+	tx := NewDelayedTx(sdi.dbWriter.db)
 	defer func() {
 		if p := recover(); p != nil {
 			rollback(sdi.ctx, tx)
@@ -589,11 +586,8 @@ func (sdi *StateDiffIndexer) LoadWatchedAddresses() ([]common.Address, error) {
 }
 
 // InsertWatchedAddresses inserts the given addresses in the database
-func (sdi *StateDiffIndexer) InsertWatchedAddresses(args []sdtypes.WatchAddressArg, currentBlockNumber *big.Int) error {
-	tx, err := sdi.dbWriter.db.Begin(sdi.ctx)
-	if err != nil {
-		return err
-	}
+func (sdi *StateDiffIndexer) InsertWatchedAddresses(args []sdtypes.WatchAddressArg, currentBlockNumber *big.Int) (err error) {
+	tx := NewDelayedTx(sdi.dbWriter.db)
 	defer func() {
 		if p := recover(); p != nil {
 			rollback(sdi.ctx, tx)
@@ -617,11 +611,8 @@ func (sdi *StateDiffIndexer) InsertWatchedAddresses(args []sdtypes.WatchAddressA
 }
 
 // RemoveWatchedAddresses removes the given watched addresses from the database
-func (sdi *StateDiffIndexer) RemoveWatchedAddresses(args []sdtypes.WatchAddressArg) error {
-	tx, err := sdi.dbWriter.db.Begin(sdi.ctx)
-	if err != nil {
-		return err
-	}
+func (sdi *StateDiffIndexer) RemoveWatchedAddresses(args []sdtypes.WatchAddressArg) (err error) {
+	tx := NewDelayedTx(sdi.dbWriter.db)
 	defer func() {
 		if p := recover(); p != nil {
 			rollback(sdi.ctx, tx)
@@ -644,11 +635,8 @@ func (sdi *StateDiffIndexer) RemoveWatchedAddresses(args []sdtypes.WatchAddressA
 }
 
 // SetWatchedAddresses clears and inserts the given addresses in the database
-func (sdi *StateDiffIndexer) SetWatchedAddresses(args []sdtypes.WatchAddressArg, currentBlockNumber *big.Int) error {
-	tx, err := sdi.dbWriter.db.Begin(sdi.ctx)
-	if err != nil {
-		return err
-	}
+func (sdi *StateDiffIndexer) SetWatchedAddresses(args []sdtypes.WatchAddressArg, currentBlockNumber *big.Int) (err error) {
+	tx := NewDelayedTx(sdi.dbWriter.db)
 	defer func() {
 		if p := recover(); p != nil {
 			rollback(sdi.ctx, tx)

--- a/statediff/indexer/database/sql/lazy_tx.go
+++ b/statediff/indexer/database/sql/lazy_tx.go
@@ -1,0 +1,55 @@
+package sql
+
+import (
+	"context"
+)
+
+type DelayedTx struct {
+	cache []cachedStmt
+	db    Database
+}
+type cachedStmt struct {
+	sql  string
+	args []interface{}
+}
+
+func NewDelayedTx(db Database) *DelayedTx {
+	return &DelayedTx{db: db}
+}
+
+func (tx *DelayedTx) QueryRow(ctx context.Context, sql string, args ...interface{}) ScannableRow {
+	return tx.db.QueryRow(ctx, sql, args...)
+}
+
+func (tx *DelayedTx) Exec(ctx context.Context, sql string, args ...interface{}) (Result, error) {
+	tx.cache = append(tx.cache, cachedStmt{sql, args})
+	return nil, nil
+}
+
+func (tx *DelayedTx) Commit(ctx context.Context) error {
+	base, err := tx.db.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if p := recover(); p != nil {
+			rollback(ctx, base)
+			panic(p)
+		} else if err != nil {
+			rollback(ctx, base)
+		}
+	}()
+	for _, stmt := range tx.cache {
+		_, err := base.Exec(ctx, stmt.sql, stmt.args...)
+		if err != nil {
+			return err
+		}
+	}
+	tx.cache = nil
+	return base.Commit(ctx)
+}
+
+func (tx *DelayedTx) Rollback(ctx context.Context) error {
+	tx.cache = nil
+	return nil
+}


### PR DESCRIPTION
Implements a `Tx` object that caches SQL statements, then builds and commits the underlying transaction at `Commit`.

Closes https://github.com/cerc-io/go-ethereum/issues/294