### PR TITLE
No-UPSERT mode

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -244,6 +244,9 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 					ClientName:   clientName,
 					Driver:       driverType,
 				}
+				if ctx.IsSet(utils.StateDiffUpsert.Name) {
+					pgConfig.Upsert = ctx.Bool(utils.StateDiffUpsert.Name)
+				}
 				if ctx.IsSet(utils.StateDiffDBMinConns.Name) {
 					pgConfig.MinConns = ctx.Int(utils.StateDiffDBMinConns.Name)
 				}

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -179,6 +179,7 @@ var (
 		utils.StateDiffKnownGapsFilePath,
 		utils.StateDiffWaitForSync,
 		utils.StateDiffWatchedAddressesFilePath,
+		utils.StateDiffUpsert,
 		configFileFlag,
 	}, utils.NetworkFlags, utils.DatabasePathFlags)
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1078,6 +1078,11 @@ var (
 		Usage: "Client name to use when writing state diffs to database",
 		Value: "go-ethereum",
 	}
+	StateDiffUpsert = &cli.BoolFlag{
+		Name:  "statediff.db.upsert",
+		Usage: "Should the statediff service overwrite data existing in the database?",
+		Value: false,
+	}
 	StateDiffWritingFlag = &cli.BoolFlag{
 		Name:  "statediff.writing",
 		Usage: "Activates progressive writing of state diffs to database as new block are synced",

--- a/statediff/README.md
+++ b/statediff/README.md
@@ -118,6 +118,8 @@ This service introduces a CLI flag namespace `statediff`
 
 `--statediff.db.clientname` is the client name to use in the Postgres database
 
+`--statediff.db.upsert` whether or not the service, when operating in a direct database writing mode, should overwrite any existing conflicting data
+
 `--statediff.file.path` full path (including filename) to write statediff data out to when operating in file mode
 
 `--statediff.file.wapath` full path (including filename) to write statediff watched addresses out to when operating in file mode

--- a/statediff/indexer/constructor.go
+++ b/statediff/indexer/constructor.go
@@ -65,7 +65,7 @@ func NewStateDiffIndexer(ctx context.Context, chainConfig *params.ChainConfig, n
 		default:
 			return nil, nil, fmt.Errorf("unrecognized Postgres driver type: %s", pgc.Driver)
 		}
-		db := postgres.NewPostgresDB(driver)
+		db := postgres.NewPostgresDB(driver, pgc.Upsert)
 		ind, err := sql.NewStateDiffIndexer(ctx, chainConfig, db)
 		return db, ind, err
 	case shared.DUMP:

--- a/statediff/indexer/database/sql/postgres/config.go
+++ b/statediff/indexer/database/sql/postgres/config.go
@@ -77,6 +77,9 @@ type Config struct {
 
 	// driver type
 	Driver DriverType
+
+	// toggle on/off upserts
+	Upsert bool
 }
 
 // Type satisfies interfaces.Config

--- a/statediff/indexer/database/sql/postgres/test_helpers.go
+++ b/statediff/indexer/database/sql/postgres/test_helpers.go
@@ -31,7 +31,7 @@ func SetupSQLXDB() (sql.Database, error) {
 	if err != nil {
 		return nil, err
 	}
-	return NewPostgresDB(driver), nil
+	return NewPostgresDB(driver, false), nil
 }
 
 // SetupPGXDB is used to setup a pgx db for tests
@@ -40,5 +40,5 @@ func SetupPGXDB() (sql.Database, error) {
 	if err != nil {
 		return nil, err
 	}
-	return NewPostgresDB(driver), nil
+	return NewPostgresDB(driver, false), nil
 }


### PR DESCRIPTION
For #299 

Upserts are now configurable (off by default) where they were previously hard-coded. Rather than removing them completely, they are left in as an option at the indexer package level as they could still be useful in certain situations in eth-statediff-service and other dependent tools. It is also currently left in as a configurable option at the service level here in order to aid with testing.