### PR TITLE
Add --statediff.db.logstatements option.

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -265,6 +265,9 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 				if ctx.IsSet(utils.StateDiffDBConnTimeout.Name) {
 					pgConfig.ConnTimeout = time.Duration(ctx.Duration(utils.StateDiffDBConnTimeout.Name).Seconds())
 				}
+				if ctx.IsSet(utils.StateDiffLogStatements.Name) {
+					pgConfig.LogStatements = ctx.Bool(utils.StateDiffLogStatements.Name)
+				}
 				indexerConfig = pgConfig
 			case shared.DUMP:
 				dumpTypeStr := ctx.String(utils.StateDiffDBDumpDst.Name)

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -179,6 +179,7 @@ var (
 		utils.StateDiffWaitForSync,
 		utils.StateDiffWatchedAddressesFilePath,
 		utils.StateDiffUpsert,
+		utils.StateDiffLogStatements,
 		configFileFlag,
 	}, utils.NetworkFlags, utils.DatabasePathFlags)
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1078,6 +1078,11 @@ var (
 		Usage: "Should the statediff service overwrite data existing in the database?",
 		Value: false,
 	}
+	StateDiffLogStatements = &cli.BoolFlag{
+		Name:  "statediff.db.logstatements",
+		Usage: "Should the statediff service log all database statements?",
+		Value: false,
+	}
 	StateDiffWritingFlag = &cli.BoolFlag{
 		Name:  "statediff.writing",
 		Usage: "Activates progressive writing of state diffs to database as new block are synced",

--- a/statediff/indexer/database/sql/postgres/config.go
+++ b/statediff/indexer/database/sql/postgres/config.go
@@ -70,6 +70,7 @@ type Config struct {
 	MaxConnIdleTime time.Duration
 	MaxConnLifetime time.Duration
 	ConnTimeout     time.Duration
+	LogStatements   bool
 
 	// node info params
 	ID         string

--- a/statediff/indexer/database/sql/postgres/log_adapter.go
+++ b/statediff/indexer/database/sql/postgres/log_adapter.go
@@ -1,0 +1,46 @@
+package postgres
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/jackc/pgx/v4"
+)
+
+type LogAdapter struct {
+	l log.Logger
+}
+
+func NewLogAdapter(l log.Logger) *LogAdapter {
+	return &LogAdapter{l: l}
+}
+
+func (l *LogAdapter) Log(ctx context.Context, level pgx.LogLevel, msg string, data map[string]interface{}) {
+	var logger log.Logger
+	if data != nil {
+		var args = make([]interface{}, 0)
+		for key, value := range data {
+			if value != nil {
+				args = append(args, key, value)
+			}
+		}
+		logger = l.l.New(args...)
+	} else {
+		logger = l.l
+	}
+
+	switch level {
+	case pgx.LogLevelTrace:
+		logger.Trace(msg)
+	case pgx.LogLevelDebug:
+		logger.Debug(msg)
+	case pgx.LogLevelInfo:
+		logger.Info(msg)
+	case pgx.LogLevelWarn:
+		logger.Warn(msg)
+	case pgx.LogLevelError:
+		logger.Error(msg)
+	default:
+		logger.New("INVALID_PGX_LOG_LEVEL", level).Error(msg)
+	}
+}

--- a/statediff/indexer/database/sql/postgres/log_adapter.go
+++ b/statediff/indexer/database/sql/postgres/log_adapter.go
@@ -1,3 +1,18 @@
+// Copyright © 2023 Cerc
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package postgres
 
 import (

--- a/statediff/indexer/database/sql/postgres/pgx.go
+++ b/statediff/indexer/database/sql/postgres/pgx.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/ethereum/go-ethereum/log"
+
 	"github.com/georgysavva/scany/pgxscan"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
@@ -85,6 +87,11 @@ func MakeConfig(config Config) (*pgxpool.Config, error) {
 	if config.MaxConnIdleTime != 0 {
 		conf.MaxConnIdleTime = config.MaxConnIdleTime
 	}
+
+	if config.LogStatements {
+		conf.ConnConfig.Logger = NewLogAdapter(log.New())
+	}
+
 	return conf, nil
 }
 


### PR DESCRIPTION
Add a new option `--statediff.db.logstatements=true|false` which will control the logging of statesdiff-related DB statements.

Example output:

```
INFO [01-13|19:55:37.564] Exec    time=13.723527ms  commandTag=BEGIN  pid=116 sql=begin  args=[]
INFO [01-13|19:55:37.578] Exec    pid=116 sql="INSERT INTO eth.header_cids (block_number, block_hash, parent_hash, cid, td, node_id, reward, state_root, tx_root, receipt_root, uncle_root, bloom, timestamp, mh_key, times_validated, coinbase)\n\t\t\tVALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)\n\t\t\tON CONFLICT (block_hash, block_number) DO NOTHING" args="[60xc2e8c50927247be4bcefc13bb833055bb27605350a15522a24d72d42e6bd04 (truncated 2 bytes) 0x080cccc990712b44bfa1ac09269fd090f0217d0803873a37581d69cfdff317 (truncated 2 bytes) bagiacgzaylumkcjher56jphpye53qmyflozhmbjvbikvekre24wufzv5asma 131073 1 5000681080004767560 0xa8e92eb7dbd1a265329d9539575f45b37bcc1a40fb83bee49b63262cce2cd2 (truncated 2 bytes) 0xf500a40de2642     a3f52bc79d103511e446aaab35ab501d23e8b8b23c4c58040 (truncated 2 bytes) 0xe04eef37a26925528776834c6af2c369d6d44a3db2438f3776aa832f6ba597 (truncated 2 bytes) 0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d493 (truncated 2 bytes) 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 (truncated 192 bytes) 1673639735 /blocks/DMQMF2GFBETSI67EXTX4CO5YGMCVXMTWAU2QUFKSFISNOLKC426QJGA 1 0xe6CE22afe802CAf5fF7d3845cec8c736ecc8d61F]" time=12.984251ms  commandTag="INSERT 0 1"
INFO [01-13|19:55:37.599] Exec    sql="INSERT INTO eth.transaction_cids (block_number, header_id, tx_hash, cid, dst, src, index, mh_key, tx_data, tx_type, value) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)\n\t\t\tON CONFLICT (tx_hash, header_id, block_number) DO NOTHING" args="[6 0xc2e8c50927247be4bcefc13bb833055bb27605350a15522a24d72d42e6bd04 (truncated 2 bytes) 0x1875c9b082746dc76a12267491c45add07ac8c81cbe522462ab1836cdefa0d (truncated 2 bytes) bagjqcgzadb24tmecorw4o2qsez2jdrc23ud2zdebzpsserrkwgbwzxx2bunq 0xbA85C92cCB1dF0C51b6054C26662E771B     49DbbD7 0xf1ac8Dd1f6D6F5c0dA99097c57ebF50CD99Ce293 0 /blocks/DMQBQ5OJWCBHI3OHNIJCM5ERYRNN2B5MRSA4XZJCIYVLDA3M335A2GY 2802348a000000000000000000000000ba85c92ccb1df0c51b6054c26662e771b49dbbd700000000     000000000000000000000000000000000000000000000000 (truncated 4 bytes) 2 0]" time=20.450095ms  commandTag="INSERT 0 1"   pid=116
```