### PR TITLE
Add finer-grained logging and timers for statediffing.

### DIFF
--- a/statediff/builder.go
+++ b/statediff/builder.go
@@ -207,7 +207,7 @@ func (sdb *StateDiffBuilder) WriteStateDiffObject(args Args, params Params, outp
 
 func (sdb *StateDiffBuilder) BuildStateDiffWithIntermediateStateNodes(iterPairs []IterPair, params Params, output types2.StateNodeSink, codeOutput types2.CodeSink, logger log.Logger) error {
 	start, t := time.Now(), time.Now()
-	defer logger.Debug(fmt.Sprintf("statediff BuildStateDiffWithIntermediateStateNodes duration=%dms", time.Since(start).Milliseconds()))
+	defer logger.Debug(fmt.Sprintf("statediff BuildStateDiffWithIntermediateStateNodes total duration=%dms", time.Since(start).Milliseconds()))
 	// collect a slice of all the nodes that were touched and exist at B (B-A)
 	// a map of their leafkey to all the accounts that were touched and exist at B
 	// and a slice of all the paths for the nodes in both of the above sets
@@ -231,7 +231,7 @@ func (sdb *StateDiffBuilder) BuildStateDiffWithIntermediateStateNodes(iterPairs 
 	t = time.Now()
 	createKeys := trie_helpers.SortKeys(diffAccountsAtB)
 	deleteKeys := trie_helpers.SortKeys(diffAccountsAtA)
-	logger.Debug(fmt.Sprintf("statediff BuildStateDiffWithIntermediateStateNodes - sorting keys duration=%dms", time.Since(t).Milliseconds()))
+	logger.Debug(fmt.Sprintf("statediff BuildStateDiffWithIntermediateStateNodes sort duration=%dms", time.Since(t).Milliseconds()))
 
 	// and then find the intersection of these keys
 	// these are the leafkeys for the accounts which exist at both A and B but are different
@@ -239,7 +239,7 @@ func (sdb *StateDiffBuilder) BuildStateDiffWithIntermediateStateNodes(iterPairs 
 	// and leaving the truly created or deleted keys in place
 	t = time.Now()
 	updatedKeys := trie_helpers.FindIntersection(createKeys, deleteKeys)
-	logger.Debug(fmt.Sprintf("statediff BuildStateDiffWithIntermediateStateNodes - finding intersection count=%d duration=%dms",
+	logger.Debug(fmt.Sprintf("statediff BuildStateDiffWithIntermediateStateNodes intersection count=%d duration=%dms",
 		len(updatedKeys),
 		time.Since(t).Milliseconds()))
 
@@ -260,7 +260,7 @@ func (sdb *StateDiffBuilder) BuildStateDiffWithIntermediateStateNodes(iterPairs 
 
 func (sdb *StateDiffBuilder) BuildStateDiffWithoutIntermediateStateNodes(iterPairs []IterPair, params Params, output types2.StateNodeSink, codeOutput types2.CodeSink, logger log.Logger) error {
 	start, t := time.Now(), time.Now()
-	defer logger.Debug(fmt.Sprintf("statediff BuildStateDiffWithoutIntermediateStateNodes duration=%dms", time.Since(start).Milliseconds()))
+	defer logger.Debug(fmt.Sprintf("statediff BuildStateDiffWithoutIntermediateStateNodes total duration=%dms", time.Since(start).Milliseconds()))
 	// collect a map of their leafkey to all the accounts that were touched and exist at B
 	// and a slice of all the paths for the nodes in both of the above sets
 	diffAccountsAtB, diffPathsAtB, err := sdb.createdAndUpdatedState(
@@ -284,7 +284,7 @@ func (sdb *StateDiffBuilder) BuildStateDiffWithoutIntermediateStateNodes(iterPai
 	t = time.Now()
 	createKeys := trie_helpers.SortKeys(diffAccountsAtB)
 	deleteKeys := trie_helpers.SortKeys(diffAccountsAtA)
-	logger.Debug(fmt.Sprintf("statediff BuildStateDiffWithoutIntermediateStateNodes - sorting keys duration=%dms", time.Since(t).Milliseconds()))
+	logger.Debug(fmt.Sprintf("statediff BuildStateDiffWithoutIntermediateStateNodessort sort duration=%dms", time.Since(t).Milliseconds()))
 
 	// and then find the intersection of these keys
 	// these are the leafkeys for the accounts which exist at both A and B but are different
@@ -292,7 +292,7 @@ func (sdb *StateDiffBuilder) BuildStateDiffWithoutIntermediateStateNodes(iterPai
 	// and leaving the truly created or deleted keys in place
 	t = time.Now()
 	updatedKeys := trie_helpers.FindIntersection(createKeys, deleteKeys)
-	logger.Debug(fmt.Sprintf("statediff BuildStateDiffWithoutIntermediateStateNodes - finding intersection count=%d duration=%dms",
+	logger.Debug(fmt.Sprintf("statediff BuildStateDiffWithoutIntermediateStateNodes intersection count=%d duration=%dms",
 		len(updatedKeys),
 		time.Since(t).Milliseconds()))
 

--- a/statediff/builder.go
+++ b/statediff/builder.go
@@ -206,7 +206,7 @@ func (sdb *StateDiffBuilder) WriteStateDiffObject(args Args, params Params, outp
 }
 
 func (sdb *StateDiffBuilder) BuildStateDiffWithIntermediateStateNodes(iterPairs []IterPair, params Params, output types2.StateNodeSink, codeOutput types2.CodeSink, logger log.Logger) error {
-	start, t := time.Now(), time.Now()
+	start := time.Now()
 	defer logger.Debug(fmt.Sprintf("statediff BuildStateDiffWithIntermediateStateNodes total duration=%dms", time.Since(start).Milliseconds()))
 	// collect a slice of all the nodes that were touched and exist at B (B-A)
 	// a map of their leafkey to all the accounts that were touched and exist at B
@@ -228,7 +228,7 @@ func (sdb *StateDiffBuilder) BuildStateDiffWithIntermediateStateNodes(iterPairs 
 	}
 
 	// collect and sort the leafkey keys for both account mappings into a slice
-	t = time.Now()
+	t := time.Now()
 	createKeys := trie_helpers.SortKeys(diffAccountsAtB)
 	deleteKeys := trie_helpers.SortKeys(diffAccountsAtA)
 	logger.Debug(fmt.Sprintf("statediff BuildStateDiffWithIntermediateStateNodes sort duration=%dms", time.Since(t).Milliseconds()))
@@ -259,7 +259,7 @@ func (sdb *StateDiffBuilder) BuildStateDiffWithIntermediateStateNodes(iterPairs 
 }
 
 func (sdb *StateDiffBuilder) BuildStateDiffWithoutIntermediateStateNodes(iterPairs []IterPair, params Params, output types2.StateNodeSink, codeOutput types2.CodeSink, logger log.Logger) error {
-	start, t := time.Now(), time.Now()
+	start := time.Now()
 	defer logger.Debug(fmt.Sprintf("statediff BuildStateDiffWithoutIntermediateStateNodes total duration=%dms", time.Since(start).Milliseconds()))
 	// collect a map of their leafkey to all the accounts that were touched and exist at B
 	// and a slice of all the paths for the nodes in both of the above sets
@@ -281,7 +281,7 @@ func (sdb *StateDiffBuilder) BuildStateDiffWithoutIntermediateStateNodes(iterPai
 	}
 
 	// collect and sort the leafkeys for both account mappings into a slice
-	t = time.Now()
+	t := time.Now()
 	createKeys := trie_helpers.SortKeys(diffAccountsAtB)
 	deleteKeys := trie_helpers.SortKeys(diffAccountsAtA)
 	logger.Debug(fmt.Sprintf("statediff BuildStateDiffWithoutIntermediateStateNodessort sort duration=%dms", time.Since(t).Milliseconds()))

--- a/statediff/builder.go
+++ b/statediff/builder.go
@@ -239,7 +239,9 @@ func (sdb *StateDiffBuilder) BuildStateDiffWithIntermediateStateNodes(iterPairs 
 	// and leaving the truly created or deleted keys in place
 	t = time.Now()
 	updatedKeys := trie_helpers.FindIntersection(createKeys, deleteKeys)
-	logger.Debug(fmt.Sprintf("statediff BuildStateDiffWithIntermediateStateNodes - finding intersection duration=%dms", time.Since(t).Milliseconds()))
+	logger.Debug(fmt.Sprintf("statediff BuildStateDiffWithIntermediateStateNodes - finding intersection count=%d duration=%dms",
+		len(updatedKeys),
+		time.Since(t).Milliseconds()))
 
 	// build the diff nodes for the updated accounts using the mappings at both A and B as directed by the keys found as the intersection of the two
 	err = sdb.buildAccountUpdates(
@@ -290,7 +292,9 @@ func (sdb *StateDiffBuilder) BuildStateDiffWithoutIntermediateStateNodes(iterPai
 	// and leaving the truly created or deleted keys in place
 	t = time.Now()
 	updatedKeys := trie_helpers.FindIntersection(createKeys, deleteKeys)
-	logger.Debug(fmt.Sprintf("statediff BuildStateDiffWithoutIntermediateStateNodes - finding intersection duration=%dms", time.Since(t).Milliseconds()))
+	logger.Debug(fmt.Sprintf("statediff BuildStateDiffWithoutIntermediateStateNodes - finding intersection count=%d duration=%dms",
+		len(updatedKeys),
+		time.Since(t).Milliseconds()))
 
 	// build the diff nodes for the updated accounts using the mappings at both A and B as directed by the keys found as the intersection of the two
 	err = sdb.buildAccountUpdates(

--- a/statediff/service.go
+++ b/statediff/service.go
@@ -867,9 +867,11 @@ func (sds *Service) writeStateDiff(block *types.Block, parentRoot common.Hash, p
 		return sds.indexer.PushCodeAndCodeHash(tx, c)
 	}
 
-	err = sds.Builder.WriteStateDiffObject(types2.StateRoots{
+	err = sds.Builder.WriteStateDiffObject(Args{
 		NewStateRoot: block.Root(),
 		OldStateRoot: parentRoot,
+		BlockHash:    block.Hash(),
+		BlockNumber:  block.Number(),
 	}, params, output, codeOutput)
 	// TODO this anti-pattern needs to be sorted out eventually
 	if err := tx.Submit(err); err != nil {

--- a/statediff/test_helpers/mocks/builder.go
+++ b/statediff/test_helpers/mocks/builder.go
@@ -42,8 +42,8 @@ func (builder *Builder) BuildStateDiffObject(args statediff.Args, params statedi
 }
 
 // BuildStateDiffObject mock method
-func (builder *Builder) WriteStateDiffObject(args sdtypes.StateRoots, params statediff.Params, output sdtypes.StateNodeSink, codeOutput sdtypes.CodeSink) error {
-	builder.StateRoots = args
+func (builder *Builder) WriteStateDiffObject(args statediff.Args, params statediff.Params, output sdtypes.StateNodeSink, codeOutput sdtypes.CodeSink) error {
+	builder.StateRoots = sdtypes.StateRoots{OldStateRoot: args.OldStateRoot, NewStateRoot: args.NewStateRoot}
 	builder.Params = params
 
 	return builder.builderError


### PR DESCRIPTION
Example output:

```
DEBUG[02-04|06:08:18.098] statediff createdAndUpdatedStateWithIntermediateNodes duration=0ms hash=0x6bb96a91fcd17482ddfa7eec5020bbe29bfe957adf85eb3658e83b99c862f3e9 number=15
DEBUG[02-04|06:08:18.100] statediff deletedOrUpdatedState duration=0ms hash=0x6bb96a91fcd17482ddfa7eec5020bbe29bfe957adf85eb3658e83b99c862f3e9 number=15
DEBUG[02-04|06:08:18.102] statediff BuildStateDiffWithIntermediateStateNodes sort duration=0ms hash=0x6bb96a91fcd17482ddfa7eec5020bbe29bfe957adf85eb3658e83b99c862f3e9 number=15
DEBUG[02-04|06:08:18.106] statediff BuildStateDiffWithIntermediateStateNodes intersection count=18 duration=0ms hash=0x6bb96a91fcd17482ddfa7eec5020bbe29bfe957adf85eb3658e83b99c862f3e9 number=15
DEBUG[02-04|06:08:18.107] statediff buildAccountUpdates duration=0ms hash=0x6bb96a91fcd17482ddfa7eec5020bbe29bfe957adf85eb3658e83b99c862f3e9 number=15
DEBUG[02-04|06:08:18.113] statediff buildAccountCreations duration=0ms hash=0x6bb96a91fcd17482ddfa7eec5020bbe29bfe957adf85eb3658e83b99c862f3e9 number=15
DEBUG[02-04|06:08:18.117] statediff BuildStateDiffWithIntermediateStateNodes total duration=0ms hash=0x6bb96a91fcd17482ddfa7eec5020bbe29bfe957adf85eb3658e83b99c862f3e9 number=15
```