### PR TITLE
Add timers and update StandardTimer to include total time.

### DIFF
--- a/metrics/prometheus/collector.go
+++ b/metrics/prometheus/collector.go
@@ -85,7 +85,6 @@ func (c *collector) addTimer(name string, m metrics.Timer) {
 
 	c.buff.WriteString(fmt.Sprintf(typeGaugeTpl, mutateKey(name+"_total")))
 	c.buff.WriteString(fmt.Sprintf(keyValueTpl, mutateKey(name+"_total"), m.Total()))
-	c.buff.WriteRune('\n')
 }
 
 func (c *collector) addResettingTimer(name string, m metrics.ResettingTimer) {

--- a/metrics/prometheus/collector.go
+++ b/metrics/prometheus/collector.go
@@ -78,11 +78,13 @@ func (c *collector) addTimer(name string, m metrics.Timer) {
 	ps := m.Percentiles(pv)
 	c.writeSummaryCounter(name, m.Count())
 	c.buff.WriteString(fmt.Sprintf(typeSummaryTpl, mutateKey(name)))
-	c.buff.WriteString(fmt.Sprintf(typeGaugeTpl, mutateKey(name+"_total")))
-	c.buff.WriteString(fmt.Sprintf(keyValueTpl, mutateKey(name+"_total"), m.Total()))
 	for i := range pv {
 		c.writeSummaryPercentile(name, strconv.FormatFloat(pv[i], 'f', -1, 64), ps[i])
 	}
+	c.buff.WriteRune('\n')
+
+	c.buff.WriteString(fmt.Sprintf(typeGaugeTpl, mutateKey(name+"_total")))
+	c.buff.WriteString(fmt.Sprintf(keyValueTpl, mutateKey(name+"_total"), m.Total()))
 	c.buff.WriteRune('\n')
 }
 

--- a/metrics/prometheus/collector.go
+++ b/metrics/prometheus/collector.go
@@ -78,6 +78,8 @@ func (c *collector) addTimer(name string, m metrics.Timer) {
 	ps := m.Percentiles(pv)
 	c.writeSummaryCounter(name, m.Count())
 	c.buff.WriteString(fmt.Sprintf(typeSummaryTpl, mutateKey(name)))
+	c.buff.WriteString(fmt.Sprintf(typeGaugeTpl, mutateKey(name+"_total")))
+	c.buff.WriteString(fmt.Sprintf(keyValueTpl, mutateKey(name+"_total"), m.Total()))
 	for i := range pv {
 		c.writeSummaryPercentile(name, strconv.FormatFloat(pv[i], 'f', -1, 64), ps[i])
 	}

--- a/metrics/prometheus/collector_test.go
+++ b/metrics/prometheus/collector_test.go
@@ -92,6 +92,9 @@ test_timer {quantile="0.99"} 1.2e+08
 test_timer {quantile="0.999"} 1.2e+08
 test_timer {quantile="0.9999"} 1.2e+08
 
+# TYPE test_timer_total gauge
+test_timer_total 230000000
+
 # TYPE test_resetting_timer_count counter
 test_resetting_timer_count 6
 

--- a/metrics/timer.go
+++ b/metrics/timer.go
@@ -137,6 +137,7 @@ func (NilTimer) UpdateSince(time.Time) {}
 // Variance is a no-op.
 func (NilTimer) Variance() float64 { return 0.0 }
 
+// Total is a no-op.
 func (NilTimer) Total() int64 { return int64(0) }
 
 // StandardTimer is the standard implementation of a Timer and uses a Histogram
@@ -251,6 +252,9 @@ func (t *StandardTimer) Variance() float64 {
 	return t.histogram.Variance()
 }
 
+// Total returns the total time the timer has run in nanoseconds.
+// This differs from Sum in that it is a simple counter, not based
+// on a histogram Sample.
 func (t *StandardTimer) Total() int64 {
 	return t.total.Count()
 }
@@ -335,4 +339,5 @@ func (*TimerSnapshot) UpdateSince(time.Time) {
 // taken.
 func (t *TimerSnapshot) Variance() float64 { return t.histogram.Variance() }
 
+// Total returns the total time the timer has run in nanoseconds.
 func (t *TimerSnapshot) Total() int64 { return t.total.Count() }

--- a/statediff/builder.go
+++ b/statediff/builder.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/ethereum/go-ethereum/metrics"
 	metrics2 "github.com/ethereum/go-ethereum/statediff/indexer/database/metrics"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -210,7 +209,7 @@ func (sdb *StateDiffBuilder) WriteStateDiffObject(args Args, params Params, outp
 
 func (sdb *StateDiffBuilder) BuildStateDiffWithIntermediateStateNodes(iterPairs []IterPair, params Params, output types2.StateNodeSink, codeOutput types2.CodeSink, logger log.Logger) error {
 	logger.Debug("statediff BEGIN BuildStateDiffWithIntermediateStateNodes")
-	defer timeDuration("statediff END BuildStateDiffWithIntermediateStateNodes", time.Now(), logger, metrics2.IndexerMetrics.BuildStateDiffWithIntermediateStateNodesTimer)
+	defer metrics2.ReportAndUpdateDuration("statediff END BuildStateDiffWithIntermediateStateNodes", time.Now(), logger, metrics2.IndexerMetrics.BuildStateDiffWithIntermediateStateNodesTimer)
 	// collect a slice of all the nodes that were touched and exist at B (B-A)
 	// a map of their leafkey to all the accounts that were touched and exist at B
 	// and a slice of all the paths for the nodes in both of the above sets
@@ -263,7 +262,7 @@ func (sdb *StateDiffBuilder) BuildStateDiffWithIntermediateStateNodes(iterPairs 
 
 func (sdb *StateDiffBuilder) BuildStateDiffWithoutIntermediateStateNodes(iterPairs []IterPair, params Params, output types2.StateNodeSink, codeOutput types2.CodeSink, logger log.Logger) error {
 	logger.Debug("statediff BEGIN BuildStateDiffWithoutIntermediateStateNodes")
-	defer timeDuration("statediff END BuildStateDiffWithoutIntermediateStateNodes", time.Now(), logger, metrics2.IndexerMetrics.BuildStateDiffWithoutIntermediateStateNodesTimer)
+	defer metrics2.ReportAndUpdateDuration("statediff END BuildStateDiffWithoutIntermediateStateNodes", time.Now(), logger, metrics2.IndexerMetrics.BuildStateDiffWithoutIntermediateStateNodesTimer)
 	// collect a map of their leafkey to all the accounts that were touched and exist at B
 	// and a slice of all the paths for the nodes in both of the above sets
 	diffAccountsAtB, diffPathsAtB, err := sdb.createdAndUpdatedState(
@@ -375,12 +374,12 @@ func (sdb *StateDiffBuilder) createdAndUpdatedState(a, b trie.NodeIterator, watc
 // and a slice of the paths for all of the nodes included in both
 func (sdb *StateDiffBuilder) createdAndUpdatedStateWithIntermediateNodes(a, b trie.NodeIterator, watchedAddressesLeafPaths [][]byte, output types2.StateNodeSink, logger log.Logger) (types2.AccountMap, map[string]bool, error) {
 	logger.Debug("statediff BEGIN createdAndUpdatedStateWithIntermediateNodes")
-	defer timeDuration("statediff END createdAndUpdatedStateWithIntermediateNodes", time.Now(), logger, metrics2.IndexerMetrics.CreatedAndUpdatedStateWithIntermediateNodesTimer)
+	defer metrics2.ReportAndUpdateDuration("statediff END createdAndUpdatedStateWithIntermediateNodes", time.Now(), logger, metrics2.IndexerMetrics.CreatedAndUpdatedStateWithIntermediateNodesTimer)
 	diffPathsAtB := make(map[string]bool)
 	diffAccountsAtB := make(types2.AccountMap)
 	watchingAddresses := len(watchedAddressesLeafPaths) > 0
 
-	it, _ := trie.NewDifferenceIterator(a, b)
+	it, itCount := trie.NewDifferenceIterator(a, b)
 	for it.Next(true) {
 		// ignore node if it is not along paths of interest
 		if watchingAddresses && !isValidPrefixPath(watchedAddressesLeafPaths, it.Path()) {
@@ -436,6 +435,8 @@ func (sdb *StateDiffBuilder) createdAndUpdatedStateWithIntermediateNodes(a, b tr
 		// add both intermediate and leaf node paths to the list of diffPathsAtB
 		diffPathsAtB[common.Bytes2Hex(node.Path)] = true
 	}
+	logger.Debug("statediff COUNTS createdAndUpdatedStateWithIntermediateNodes", "it", itCount, "diffAccountsAtB", len(diffAccountsAtB), "diffPathsAtB", len(diffPathsAtB))
+	metrics2.IndexerMetrics.DifferenceIteratorCounter.Inc(int64(*itCount))
 	return diffAccountsAtB, diffPathsAtB, it.Error()
 }
 
@@ -443,7 +444,7 @@ func (sdb *StateDiffBuilder) createdAndUpdatedStateWithIntermediateNodes(a, b tr
 // and a mapping of their leafkeys to all the accounts that exist in a different state at A than B
 func (sdb *StateDiffBuilder) deletedOrUpdatedState(a, b trie.NodeIterator, diffAccountsAtB types2.AccountMap, diffPathsAtB map[string]bool, watchedAddressesLeafPaths [][]byte, intermediateStateNodes, intermediateStorageNodes bool, output types2.StateNodeSink, logger log.Logger) (types2.AccountMap, error) {
 	logger.Debug("statediff BEGIN deletedOrUpdatedState")
-	defer timeDuration("statediff END deletedOrUpdatedState", time.Now(), logger, metrics2.IndexerMetrics.DeletedOrUpdatedStateTimer)
+	defer metrics2.ReportAndUpdateDuration("statediff END deletedOrUpdatedState", time.Now(), logger, metrics2.IndexerMetrics.DeletedOrUpdatedStateTimer)
 	diffAccountAtA := make(types2.AccountMap)
 	watchingAddresses := len(watchedAddressesLeafPaths) > 0
 
@@ -550,8 +551,8 @@ func (sdb *StateDiffBuilder) deletedOrUpdatedState(a, b trie.NodeIterator, diffA
 // needs to be called before building account creations and deletions as this mutates
 // those account maps to remove the accounts which were updated
 func (sdb *StateDiffBuilder) buildAccountUpdates(creations, deletions types2.AccountMap, updatedKeys []string, intermediateStorageNodes bool, output types2.StateNodeSink, logger log.Logger) error {
-	logger.Debug("statediff BEGIN buildAccountUpdates")
-	defer timeDuration("statediff END buildAccountUpdates", time.Now(), logger, metrics2.IndexerMetrics.BuildAccountUpdatesTimer)
+	logger.Debug("statediff BEGIN buildAccountUpdates", "creations", len(creations), "deletions", len(deletions), "updatedKeys", len(updatedKeys))
+	defer metrics2.ReportAndUpdateDuration("statediff END buildAccountUpdates ", time.Now(), logger, metrics2.IndexerMetrics.BuildAccountUpdatesTimer)
 	var err error
 	for _, key := range updatedKeys {
 		createdAcc := creations[key]
@@ -580,6 +581,7 @@ func (sdb *StateDiffBuilder) buildAccountUpdates(creations, deletions types2.Acc
 		delete(deletions, key)
 	}
 
+	logger.Debug("Counts")
 	return nil
 }
 
@@ -587,7 +589,7 @@ func (sdb *StateDiffBuilder) buildAccountUpdates(creations, deletions types2.Acc
 // it also returns the code and codehash for created contract accounts
 func (sdb *StateDiffBuilder) buildAccountCreations(accounts types2.AccountMap, intermediateStorageNodes bool, output types2.StateNodeSink, codeOutput types2.CodeSink, logger log.Logger) error {
 	logger.Debug("statediff BEGIN buildAccountCreations")
-	defer timeDuration("statediff END buildAccountCreations", time.Now(), logger, metrics2.IndexerMetrics.BuildAccountCreationsTimer)
+	defer metrics2.ReportAndUpdateDuration("statediff END buildAccountCreations", time.Now(), logger, metrics2.IndexerMetrics.BuildAccountCreationsTimer)
 	for _, val := range accounts {
 		diff := types2.StateNode{
 			NodeType:  val.NodeType,
@@ -751,6 +753,7 @@ func (sdb *StateDiffBuilder) buildRemovedStorageNodesFromTrie(it trie.NodeIterat
 
 // buildStorageNodesIncremental builds the storage diff node objects for all nodes that exist in a different state at B than A
 func (sdb *StateDiffBuilder) buildStorageNodesIncremental(oldSR common.Hash, newSR common.Hash, intermediateNodes bool, output types2.StorageNodeSink) error {
+	defer metrics2.UpdateDuration(time.Now(), metrics2.IndexerMetrics.BuildStorageNodesIncrementalTimer)
 	if bytes.Equal(newSR.Bytes(), oldSR.Bytes()) {
 		return nil
 	}
@@ -779,6 +782,7 @@ func (sdb *StateDiffBuilder) buildStorageNodesIncremental(oldSR common.Hash, new
 }
 
 func (sdb *StateDiffBuilder) createdAndUpdatedStorage(a, b trie.NodeIterator, intermediateNodes bool, output types2.StorageNodeSink) (map[string]bool, map[string]bool, error) {
+	defer metrics2.UpdateDuration(time.Now(), metrics2.IndexerMetrics.CreatedAndUpdatedStorageTimer)
 	diffPathsAtB := make(map[string]bool)
 	diffSlotsAtB := make(map[string]bool)
 	it, _ := trie.NewDifferenceIterator(a, b)
@@ -825,6 +829,7 @@ func (sdb *StateDiffBuilder) createdAndUpdatedStorage(a, b trie.NodeIterator, in
 }
 
 func (sdb *StateDiffBuilder) deletedOrUpdatedStorage(a, b trie.NodeIterator, diffSlotsAtB, diffPathsAtB map[string]bool, intermediateNodes bool, output types2.StorageNodeSink) error {
+	defer metrics2.UpdateDuration(time.Now(), metrics2.IndexerMetrics.DeletedOrUpdatedStorageTimer)
 	it, _ := trie.NewDifferenceIterator(b, a)
 	for it.Next(true) {
 		// skip value nodes
@@ -916,10 +921,4 @@ func isWatchedAddress(watchedAddressesLeafPaths [][]byte, valueNodePath []byte) 
 	}
 
 	return false
-}
-
-func timeDuration(msg string, start time.Time, logger log.Logger, timer metrics.Timer) {
-	since := time.Since(start)
-	timer.Update(since)
-	logger.Debug(fmt.Sprintf("%s duration=%dms", msg, since.Milliseconds()))
 }

--- a/statediff/builder.go
+++ b/statediff/builder.go
@@ -581,7 +581,6 @@ func (sdb *StateDiffBuilder) buildAccountUpdates(creations, deletions types2.Acc
 		delete(deletions, key)
 	}
 
-	logger.Debug("Counts")
 	return nil
 }
 

--- a/statediff/indexer/database/metrics/metrics.go
+++ b/statediff/indexer/database/metrics/metrics.go
@@ -17,6 +17,7 @@
 package metrics
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -78,6 +79,16 @@ type IndexerMetricsHandles struct {
 	DeletedOrUpdatedStateTimer                       metrics.Timer
 	BuildAccountUpdatesTimer                         metrics.Timer
 	BuildAccountCreationsTimer                       metrics.Timer
+	ResolveNodeTimer                                 metrics.Timer
+	SortKeysTimer                                    metrics.Timer
+	FindIntersectionTimer                            metrics.Timer
+	OutputTimer                                      metrics.Timer
+	CodeOutputTimer                                  metrics.Timer
+	DifferenceIteratorNextTimer                      metrics.Timer
+	DifferenceIteratorCounter                        metrics.Counter
+	DeletedOrUpdatedStorageTimer                     metrics.Timer
+	CreatedAndUpdatedStorageTimer                    metrics.Timer
+	BuildStorageNodesIncrementalTimer                metrics.Timer
 }
 
 func RegisterIndexerMetrics(reg metrics.Registry) IndexerMetricsHandles {
@@ -99,6 +110,16 @@ func RegisterIndexerMetrics(reg metrics.Registry) IndexerMetricsHandles {
 		DeletedOrUpdatedStateTimer:                       metrics.NewTimer(),
 		BuildAccountUpdatesTimer:                         metrics.NewTimer(),
 		BuildAccountCreationsTimer:                       metrics.NewTimer(),
+		ResolveNodeTimer:                                 metrics.NewTimer(),
+		SortKeysTimer:                                    metrics.NewTimer(),
+		FindIntersectionTimer:                            metrics.NewTimer(),
+		OutputTimer:                                      metrics.NewTimer(),
+		CodeOutputTimer:                                  metrics.NewTimer(),
+		DifferenceIteratorNextTimer:                      metrics.NewTimer(),
+		DifferenceIteratorCounter:                        metrics.NewCounter(),
+		DeletedOrUpdatedStorageTimer:                     metrics.NewTimer(),
+		CreatedAndUpdatedStorageTimer:                    metrics.NewTimer(),
+		BuildStorageNodesIncrementalTimer:                metrics.NewTimer(),
 	}
 	subsys := "indexer"
 	reg.Register(metricName(subsys, "blocks"), ctx.BlocksCounter)
@@ -118,6 +139,16 @@ func RegisterIndexerMetrics(reg metrics.Registry) IndexerMetricsHandles {
 	reg.Register(metricName(subsys, "t_deleted_or_updated_state"), ctx.DeletedOrUpdatedStateTimer)
 	reg.Register(metricName(subsys, "t_build_account_updates"), ctx.BuildAccountUpdatesTimer)
 	reg.Register(metricName(subsys, "t_build_account_creations"), ctx.BuildAccountCreationsTimer)
+	reg.Register(metricName(subsys, "t_resolve_node"), ctx.ResolveNodeTimer)
+	reg.Register(metricName(subsys, "t_sort_keys"), ctx.SortKeysTimer)
+	reg.Register(metricName(subsys, "t_find_intersection"), ctx.FindIntersectionTimer)
+	reg.Register(metricName(subsys, "t_output_fn"), ctx.OutputTimer)
+	reg.Register(metricName(subsys, "t_code_output_fn"), ctx.CodeOutputTimer)
+	reg.Register(metricName(subsys, "t_difference_iterator_next"), ctx.DifferenceIteratorNextTimer)
+	reg.Register(metricName(subsys, "difference_iterator_counter"), ctx.DifferenceIteratorCounter)
+	reg.Register(metricName(subsys, "t_created_and_updated_storage"), ctx.CreatedAndUpdatedStorageTimer)
+	reg.Register(metricName(subsys, "t_deleted_or_updated_storage"), ctx.DeletedOrUpdatedStorageTimer)
+	reg.Register(metricName(subsys, "t_build_storage_nodes_incremental"), ctx.BuildStorageNodesIncrementalTimer)
 
 	log.Debug("Registering statediff indexer metrics.")
 	return ctx
@@ -188,4 +219,15 @@ func (met *dbMetricsHandles) Update(stats DbStats) {
 	met.blockedMilliseconds.Inc(stats.WaitDuration().Milliseconds())
 	met.closedMaxIdle.Inc(stats.MaxIdleClosed())
 	met.closedMaxLifetime.Inc(stats.MaxLifetimeClosed())
+}
+
+func ReportAndUpdateDuration(msg string, start time.Time, logger log.Logger, timer metrics.Timer) {
+	since := UpdateDuration(start, timer)
+	logger.Debug(fmt.Sprintf("%s duration=%dms", msg, since.Milliseconds()))
+}
+
+func UpdateDuration(start time.Time, timer metrics.Timer) time.Duration {
+	since := time.Since(start)
+	timer.Update(since)
+	return since
 }

--- a/statediff/indexer/database/metrics/metrics.go
+++ b/statediff/indexer/database/metrics/metrics.go
@@ -89,6 +89,16 @@ type IndexerMetricsHandles struct {
 	DeletedOrUpdatedStorageTimer                     metrics.Timer
 	CreatedAndUpdatedStorageTimer                    metrics.Timer
 	BuildStorageNodesIncrementalTimer                metrics.Timer
+	BuildStateTrieObjectTimer                        metrics.Timer
+	BuildStateTrieTimer                              metrics.Timer
+	BuildStateDiffObjectTimer                        metrics.Timer
+	WriteStateDiffObjectTimer                        metrics.Timer
+	CreatedAndUpdatedStateTimer                      metrics.Timer
+	BuildStorageNodesEventualTimer                   metrics.Timer
+	BuildStorageNodesFromTrieTimer                   metrics.Timer
+	BuildRemovedAccountStorageNodesTimer             metrics.Timer
+	BuildRemovedStorageNodesFromTrieTimer            metrics.Timer
+	IsWatchedAddressTimer                            metrics.Timer
 }
 
 func RegisterIndexerMetrics(reg metrics.Registry) IndexerMetricsHandles {
@@ -120,6 +130,16 @@ func RegisterIndexerMetrics(reg metrics.Registry) IndexerMetricsHandles {
 		DeletedOrUpdatedStorageTimer:                     metrics.NewTimer(),
 		CreatedAndUpdatedStorageTimer:                    metrics.NewTimer(),
 		BuildStorageNodesIncrementalTimer:                metrics.NewTimer(),
+		BuildStateTrieObjectTimer:                        metrics.NewTimer(),
+		BuildStateTrieTimer:                              metrics.NewTimer(),
+		BuildStateDiffObjectTimer:                        metrics.NewTimer(),
+		WriteStateDiffObjectTimer:                        metrics.NewTimer(),
+		CreatedAndUpdatedStateTimer:                      metrics.NewTimer(),
+		BuildStorageNodesEventualTimer:                   metrics.NewTimer(),
+		BuildStorageNodesFromTrieTimer:                   metrics.NewTimer(),
+		BuildRemovedAccountStorageNodesTimer:             metrics.NewTimer(),
+		BuildRemovedStorageNodesFromTrieTimer:            metrics.NewTimer(),
+		IsWatchedAddressTimer:                            metrics.NewTimer(),
 	}
 	subsys := "indexer"
 	reg.Register(metricName(subsys, "blocks"), ctx.BlocksCounter)
@@ -149,6 +169,16 @@ func RegisterIndexerMetrics(reg metrics.Registry) IndexerMetricsHandles {
 	reg.Register(metricName(subsys, "t_created_and_updated_storage"), ctx.CreatedAndUpdatedStorageTimer)
 	reg.Register(metricName(subsys, "t_deleted_or_updated_storage"), ctx.DeletedOrUpdatedStorageTimer)
 	reg.Register(metricName(subsys, "t_build_storage_nodes_incremental"), ctx.BuildStorageNodesIncrementalTimer)
+	reg.Register(metricName(subsys, "t_build_state_trie_object"), ctx.BuildStateTrieObjectTimer)
+	reg.Register(metricName(subsys, "t_build_state_trie"), ctx.BuildStateTrieTimer)
+	reg.Register(metricName(subsys, "t_build_statediff_object"), ctx.BuildStateDiffObjectTimer)
+	reg.Register(metricName(subsys, "t_write_statediff_object"), ctx.WriteStateDiffObjectTimer)
+	reg.Register(metricName(subsys, "t_created_and_updated_state"), ctx.CreatedAndUpdatedStateTimer)
+	reg.Register(metricName(subsys, "t_build_storage_nodes_eventual"), ctx.BuildStorageNodesEventualTimer)
+	reg.Register(metricName(subsys, "t_build_storage_nodes_from_trie"), ctx.BuildStorageNodesFromTrieTimer)
+	reg.Register(metricName(subsys, "t_build_removed_accounts_storage_nodes"), ctx.BuildRemovedAccountStorageNodesTimer)
+	reg.Register(metricName(subsys, "t_build_removed_storage_nodes_from_trie"), ctx.BuildRemovedStorageNodesFromTrieTimer)
+	reg.Register(metricName(subsys, "t_is_watched_address"), ctx.IsWatchedAddressTimer)
 
 	log.Debug("Registering statediff indexer metrics.")
 	return ctx

--- a/statediff/service.go
+++ b/statediff/service.go
@@ -19,6 +19,7 @@ package statediff
 import (
 	"bytes"
 	"fmt"
+	"github.com/ethereum/go-ethereum/statediff/indexer/database/metrics"
 	"math/big"
 	"strconv"
 	"strings"
@@ -861,9 +862,11 @@ func (sds *Service) writeStateDiff(block *types.Block, parentRoot common.Hash, p
 	}
 
 	output := func(node types2.StateNode) error {
+		defer metrics.ReportAndUpdateDuration("statediff output", time.Now(), logger, metrics.IndexerMetrics.OutputTimer)
 		return sds.indexer.PushStateNode(tx, node, block.Hash().String())
 	}
 	codeOutput := func(c types2.CodeAndCodeHash) error {
+		defer metrics.ReportAndUpdateDuration("statediff codeOutput", time.Now(), logger, metrics.IndexerMetrics.CodeOutputTimer)
 		return sds.indexer.PushCodeAndCodeHash(tx, c)
 	}
 

--- a/statediff/service.go
+++ b/statediff/service.go
@@ -19,13 +19,14 @@ package statediff
 import (
 	"bytes"
 	"fmt"
-	"github.com/ethereum/go-ethereum/statediff/indexer/database/metrics"
 	"math/big"
 	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/ethereum/go-ethereum/statediff/indexer/database/metrics"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"

--- a/statediff/trie_helpers/helpers.go
+++ b/statediff/trie_helpers/helpers.go
@@ -21,10 +21,11 @@ package trie_helpers
 
 import (
 	"fmt"
-	metrics2 "github.com/ethereum/go-ethereum/statediff/indexer/database/metrics"
 	"sort"
 	"strings"
 	"time"
+
+	metrics2 "github.com/ethereum/go-ethereum/statediff/indexer/database/metrics"
 
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/statediff/types"

--- a/statediff/trie_helpers/helpers.go
+++ b/statediff/trie_helpers/helpers.go
@@ -21,8 +21,10 @@ package trie_helpers
 
 import (
 	"fmt"
+	metrics2 "github.com/ethereum/go-ethereum/statediff/indexer/database/metrics"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/statediff/types"
@@ -53,6 +55,7 @@ func CheckKeyType(elements []interface{}) (types.NodeType, error) {
 
 // ResolveNode return the state diff node pointed by the iterator.
 func ResolveNode(it trie.NodeIterator, trieDB *trie.Database) (types.StateNode, []interface{}, error) {
+	defer metrics2.UpdateDuration(time.Now(), metrics2.IndexerMetrics.ResolveNodeTimer)
 	nodePath := make([]byte, len(it.Path()))
 	copy(nodePath, it.Path())
 	node, err := trieDB.Node(it.Hash())
@@ -76,6 +79,7 @@ func ResolveNode(it trie.NodeIterator, trieDB *trie.Database) (types.StateNode, 
 
 // SortKeys sorts the keys in the account map
 func SortKeys(data types.AccountMap) []string {
+	defer metrics2.UpdateDuration(time.Now(), metrics2.IndexerMetrics.SortKeysTimer)
 	keys := make([]string, 0, len(data))
 	for key := range data {
 		keys = append(keys, key)
@@ -89,6 +93,7 @@ func SortKeys(data types.AccountMap) []string {
 // a and b must first be sorted
 // this is used to find which keys have been both "deleted" and "created" i.e. they were updated
 func FindIntersection(a, b []string) []string {
+	defer metrics2.UpdateDuration(time.Now(), metrics2.IndexerMetrics.FindIntersectionTimer)
 	lenA := len(a)
 	lenB := len(b)
 	iOfA, iOfB := 0, 0

--- a/trie/iterator.go
+++ b/trie/iterator.go
@@ -20,8 +20,9 @@ import (
 	"bytes"
 	"container/heap"
 	"errors"
-	"github.com/ethereum/go-ethereum/statediff/indexer/database/metrics"
 	"time"
+
+	"github.com/ethereum/go-ethereum/statediff/indexer/database/metrics"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethdb"

--- a/trie/iterator.go
+++ b/trie/iterator.go
@@ -20,6 +20,8 @@ import (
 	"bytes"
 	"container/heap"
 	"errors"
+	"github.com/ethereum/go-ethereum/statediff/indexer/database/metrics"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethdb"
@@ -584,6 +586,7 @@ func (it *differenceIterator) AddResolver(resolver ethdb.KeyValueReader) {
 }
 
 func (it *differenceIterator) Next(bool) bool {
+	defer metrics.UpdateDuration(time.Now(), metrics.IndexerMetrics.DifferenceIteratorNextTimer)
 	// Invariants:
 	// - We always advance at least one element in b.
 	// - At the start of this function, a's path is lexically greater than b's.


### PR DESCRIPTION
Add a raft of new timers, plus change the `geth` standard timer to include a basic counter of the total rather than relying on the internal histogram.

The goal is a sort of ersatz profiling, as we will be able to see the amount of time spent in each section of the statediffing code.