### PR TITLE
Add COPY support for inserting multiple rows in a single operation.

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -248,6 +248,9 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 				if ctx.IsSet(utils.StateDiffLogStatements.Name) {
 					pgConfig.LogStatements = ctx.Bool(utils.StateDiffLogStatements.Name)
 				}
+				if ctx.IsSet(utils.StateDiffCopyFrom.Name) {
+					pgConfig.CopyFrom = ctx.Bool(utils.StateDiffCopyFrom.Name)
+				}
 				indexerConfig = pgConfig
 			case shared.DUMP:
 				dumpTypeStr := ctx.String(utils.StateDiffDBDumpDst.Name)

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -175,6 +175,7 @@ var (
 		utils.StateDiffWatchedAddressesFilePath,
 		utils.StateDiffUpsert,
 		utils.StateDiffLogStatements,
+		utils.StateDiffCopyFrom,
 		configFileFlag,
 	}, utils.NetworkFlags, utils.DatabasePathFlags)
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1100,6 +1100,13 @@ Please note that --` + MetricsHTTPFlag.Name + ` must be set to start the server.
 		Usage: "Should the statediff service log all database statements? (Note: pgx only)",
 		Value: false,
 	}
+
+	StateDiffCopyFrom = &cli.BoolFlag{
+		Name:  "statediff.db.copyfrom",
+		Usage: "Should the statediff service use COPY FROM for multiple inserts? (Note: pgx only)",
+		Value: false,
+	}
+
 	StateDiffWritingFlag = &cli.BoolFlag{
 		Name:  "statediff.writing",
 		Usage: "Activates progressive writing of state diffs to database as new block are synced",

--- a/statediff/indexer/database/sql/interfaces.go
+++ b/statediff/indexer/database/sql/interfaces.go
@@ -50,10 +50,14 @@ type Statements interface {
 	InsertTxStm() string
 	InsertAccessListElementStm() string
 	InsertRctStm() string
+	LogsTableName() []string
+	LogsColumnNames() []string
 	InsertLogStm() string
 	StateTableName() []string
 	StateColumnNames() []string
 	InsertStateStm() string
+	AccountTableName() []string
+	AccountColumnNames() []string
 	InsertAccountStm() string
 	StorageTableName() []string
 	StorageColumnNames() []string

--- a/statediff/indexer/database/sql/interfaces.go
+++ b/statediff/indexer/database/sql/interfaces.go
@@ -31,6 +31,7 @@ type Database interface {
 
 // Driver interface has all the methods required by a driver implementation to support the sql indexer
 type Driver interface {
+	UseCopyFrom() bool
 	QueryRow(ctx context.Context, sql string, args ...interface{}) ScannableRow
 	Exec(ctx context.Context, sql string, args ...interface{}) (Result, error)
 	Select(ctx context.Context, dest interface{}, query string, args ...interface{}) error
@@ -50,8 +51,12 @@ type Statements interface {
 	InsertAccessListElementStm() string
 	InsertRctStm() string
 	InsertLogStm() string
+	StateTableName() []string
+	StateColumnNames() []string
 	InsertStateStm() string
 	InsertAccountStm() string
+	StorageTableName() []string
+	StorageColumnNames() []string
 	InsertStorageStm() string
 	InsertIPLDStm() string
 	InsertIPLDsStm() string
@@ -62,6 +67,7 @@ type Statements interface {
 type Tx interface {
 	QueryRow(ctx context.Context, sql string, args ...interface{}) ScannableRow
 	Exec(ctx context.Context, sql string, args ...interface{}) (Result, error)
+	CopyFrom(ctx context.Context, tableName []string, columnNames []string, rows [][]interface{}) (int64, error)
 	Commit(ctx context.Context) error
 	Rollback(ctx context.Context) error
 }

--- a/statediff/indexer/database/sql/interfaces.go
+++ b/statediff/indexer/database/sql/interfaces.go
@@ -50,21 +50,27 @@ type Statements interface {
 	InsertTxStm() string
 	InsertAccessListElementStm() string
 	InsertRctStm() string
-	LogsTableName() []string
-	LogsColumnNames() []string
 	InsertLogStm() string
-	StateTableName() []string
-	StateColumnNames() []string
 	InsertStateStm() string
-	AccountTableName() []string
-	AccountColumnNames() []string
 	InsertAccountStm() string
-	StorageTableName() []string
-	StorageColumnNames() []string
 	InsertStorageStm() string
 	InsertIPLDStm() string
 	InsertIPLDsStm() string
 	InsertKnownGapsStm() string
+
+	// Table/column descriptions for use with CopyFrom and similar commands.
+	AccountTableName() []string
+	AccountColumnNames() []string
+	LogTableName() []string
+	LogColumnNames() []string
+	RctTableName() []string
+	RctColumnNames() []string
+	StateTableName() []string
+	StateColumnNames() []string
+	StorageTableName() []string
+	StorageColumnNames() []string
+	TxTableName() []string
+	TxColumnNames() []string
 }
 
 // Tx interface to accommodate different concrete SQL transaction types

--- a/statediff/indexer/database/sql/lazy_tx.go
+++ b/statediff/indexer/database/sql/lazy_tx.go
@@ -53,7 +53,7 @@ func (tx *DelayedTx) findPrevCopyFrom(tableName []string, columnNames []string, 
 
 func (tx *DelayedTx) CopyFrom(ctx context.Context, tableName []string, columnNames []string, rows [][]interface{}) (int64, error) {
 	if prevCopy := tx.findPrevCopyFrom(tableName, columnNames, COPY_FROM_CHECK_LIMIT); nil != prevCopy {
-		log.Info("statediff lazy_tx : Appending rows to COPY", "table", tableName,
+		log.Trace("statediff lazy_tx : Appending rows to COPY", "table", tableName,
 			"current", len(prevCopy.rows), "append", len(rows))
 		prevCopy.appendRows(rows)
 	} else {
@@ -85,7 +85,7 @@ func (tx *DelayedTx) Commit(ctx context.Context) error {
 		switch item.(type) {
 		case *copyFrom:
 			copy := item.(*copyFrom)
-			log.Info("statediff lazy_tx : COPY", "table", copy.tableName, "rows", len(copy.rows))
+			log.Trace("statediff lazy_tx : COPY", "table", copy.tableName, "rows", len(copy.rows))
 			_, err := base.CopyFrom(ctx, copy.tableName, copy.columnNames, copy.rows)
 			if err != nil {
 				return err

--- a/statediff/indexer/database/sql/lazy_tx.go
+++ b/statediff/indexer/database/sql/lazy_tx.go
@@ -54,7 +54,6 @@ func (tx *DelayedTx) Exec(ctx context.Context, sql string, args ...interface{}) 
 }
 
 func (tx *DelayedTx) Commit(ctx context.Context) error {
-
 	base, err := tx.db.Begin(ctx)
 	if err != nil {
 		return err

--- a/statediff/indexer/database/sql/lazy_tx.go
+++ b/statediff/indexer/database/sql/lazy_tx.go
@@ -2,15 +2,23 @@ package sql
 
 import (
 	"context"
+	"github.com/ethereum/go-ethereum/log"
+	"reflect"
 )
 
 type DelayedTx struct {
-	cache []cachedStmt
+	cache []interface{}
 	db    Database
 }
 type cachedStmt struct {
 	sql  string
 	args []interface{}
+}
+
+type copyFrom struct {
+	tableName   []string
+	columnNames []string
+	rows        [][]interface{}
 }
 
 func NewDelayedTx(db Database) *DelayedTx {
@@ -21,12 +29,32 @@ func (tx *DelayedTx) QueryRow(ctx context.Context, sql string, args ...interface
 	return tx.db.QueryRow(ctx, sql, args...)
 }
 
+func (tx *DelayedTx) CopyFrom(ctx context.Context, tableName []string, columnNames []string, rows [][]interface{}) (int64, error) {
+	appendedToExisting := false
+	if len(tx.cache) > 0 {
+		prevCopy, ok := tx.cache[len(tx.cache)-1].(copyFrom)
+		if ok && reflect.DeepEqual(prevCopy.tableName, tableName) && reflect.DeepEqual(prevCopy.columnNames, columnNames) {
+			log.Info("statediff lazy_tx : Appending rows to COPY", "table", tableName,
+				"current", len(prevCopy.rows), "append", len(rows))
+			prevCopy.rows = append(prevCopy.rows, rows...)
+			appendedToExisting = true
+		}
+	}
+
+	if !appendedToExisting {
+		tx.cache = append(tx.cache, copyFrom{tableName, columnNames, rows})
+	}
+
+	return 0, nil
+}
+
 func (tx *DelayedTx) Exec(ctx context.Context, sql string, args ...interface{}) (Result, error) {
 	tx.cache = append(tx.cache, cachedStmt{sql, args})
 	return nil, nil
 }
 
 func (tx *DelayedTx) Commit(ctx context.Context) error {
+
 	base, err := tx.db.Begin(ctx)
 	if err != nil {
 		return err
@@ -39,10 +67,21 @@ func (tx *DelayedTx) Commit(ctx context.Context) error {
 			rollback(ctx, base)
 		}
 	}()
-	for _, stmt := range tx.cache {
-		_, err := base.Exec(ctx, stmt.sql, stmt.args...)
-		if err != nil {
-			return err
+	for _, item := range tx.cache {
+		switch item.(type) {
+		case copyFrom:
+			copy := item.(copyFrom)
+			log.Info("statediff lazy_tx : COPY", "table", copy.tableName, "rows", len(copy.rows))
+			_, err := base.CopyFrom(ctx, copy.tableName, copy.columnNames, copy.rows)
+			if err != nil {
+				return err
+			}
+		case cachedStmt:
+			stmt := item.(cachedStmt)
+			_, err := base.Exec(ctx, stmt.sql, stmt.args...)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	tx.cache = nil

--- a/statediff/indexer/database/sql/lazy_tx.go
+++ b/statediff/indexer/database/sql/lazy_tx.go
@@ -82,17 +82,15 @@ func (tx *DelayedTx) Commit(ctx context.Context) error {
 		}
 	}()
 	for _, item := range tx.cache {
-		switch item.(type) {
+		switch item := item.(type) {
 		case *copyFrom:
-			copy := item.(*copyFrom)
-			log.Trace("statediff lazy_tx : COPY", "table", copy.tableName, "rows", len(copy.rows))
-			_, err := base.CopyFrom(ctx, copy.tableName, copy.columnNames, copy.rows)
+			log.Trace("statediff lazy_tx : COPY", "table", item.tableName, "rows", len(item.rows))
+			_, err := base.CopyFrom(ctx, item.tableName, item.columnNames, item.rows)
 			if err != nil {
 				return err
 			}
 		case cachedStmt:
-			stmt := item.(cachedStmt)
-			_, err := base.Exec(ctx, stmt.sql, stmt.args...)
+			_, err := base.Exec(ctx, item.sql, item.args...)
 			if err != nil {
 				return err
 			}

--- a/statediff/indexer/database/sql/lazy_tx.go
+++ b/statediff/indexer/database/sql/lazy_tx.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Changing this to 1 would make sure only sequential COPYs were combined.
-const COPY_FROM_CHECK_LIMIT = 100
+const copyFromCheckLimit = 100
 
 type DelayedTx struct {
 	cache []interface{}
@@ -52,7 +52,7 @@ func (tx *DelayedTx) findPrevCopyFrom(tableName []string, columnNames []string, 
 }
 
 func (tx *DelayedTx) CopyFrom(ctx context.Context, tableName []string, columnNames []string, rows [][]interface{}) (int64, error) {
-	if prevCopy := tx.findPrevCopyFrom(tableName, columnNames, COPY_FROM_CHECK_LIMIT); nil != prevCopy {
+	if prevCopy := tx.findPrevCopyFrom(tableName, columnNames, copyFromCheckLimit); nil != prevCopy {
 		log.Trace("statediff lazy_tx : Appending rows to COPY", "table", tableName,
 			"current", len(prevCopy.rows), "append", len(rows))
 		prevCopy.appendRows(rows)

--- a/statediff/indexer/database/sql/lazy_tx.go
+++ b/statediff/indexer/database/sql/lazy_tx.go
@@ -2,8 +2,9 @@ package sql
 
 import (
 	"context"
-	"github.com/ethereum/go-ethereum/log"
 	"reflect"
+
+	"github.com/ethereum/go-ethereum/log"
 )
 
 type DelayedTx struct {

--- a/statediff/indexer/database/sql/pgx_indexer_legacy_test.go
+++ b/statediff/indexer/database/sql/pgx_indexer_legacy_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func setupLegacyPGXIndexer(t *testing.T) {
-	db, err = postgres.SetupPGXDB()
+	db, err = postgres.SetupPGXDB(postgres.DefaultConfig)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/statediff/indexer/database/sql/pgx_indexer_test.go
+++ b/statediff/indexer/database/sql/pgx_indexer_test.go
@@ -29,8 +29,8 @@ import (
 	"github.com/ethereum/go-ethereum/statediff/indexer/test"
 )
 
-func setupPGXIndexer(t *testing.T) {
-	db, err = postgres.SetupPGXDB(postgres.DefaultConfig)
+func setupPGXIndexer(t *testing.T, config postgres.Config) {
+	db, err = postgres.SetupPGXDB(config)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -39,12 +39,16 @@ func setupPGXIndexer(t *testing.T) {
 }
 
 func setupPGX(t *testing.T) {
-	setupPGXIndexer(t)
+	setupPGXWithConfig(t, postgres.DefaultConfig)
+}
+
+func setupPGXWithConfig(t *testing.T, config postgres.Config) {
+	setupPGXIndexer(t, config)
 	test.SetupTestData(t, ind)
 }
 
 func setupPGXNonCanonical(t *testing.T) {
-	setupPGXIndexer(t)
+	setupPGXIndexer(t, postgres.DefaultConfig)
 	test.SetupTestDataNonCanonical(t, ind)
 }
 
@@ -96,6 +100,20 @@ func TestPGXIndexer(t *testing.T) {
 		defer checkTxClosure(t, 1, 0, 1)
 
 		test.TestPublishAndIndexStorageIPLDs(t, db)
+	})
+
+	t.Run("Publish and index with CopyFrom enabled.", func(t *testing.T) {
+		config := postgres.DefaultConfig
+		config.CopyFrom = true
+
+		setupPGXWithConfig(t, config)
+		defer tearDown(t)
+		defer checkTxClosure(t, 1, 0, 1)
+
+		test.TestPublishAndIndexStateIPLDs(t, db)
+		test.TestPublishAndIndexStorageIPLDs(t, db)
+		test.TestPublishAndIndexReceiptIPLDs(t, db)
+		test.TestPublishAndIndexLogIPLDs(t, db)
 	})
 }
 
@@ -151,7 +169,7 @@ func TestPGXIndexerNonCanonical(t *testing.T) {
 }
 
 func TestPGXWatchAddressMethods(t *testing.T) {
-	setupPGXIndexer(t)
+	setupPGXIndexer(t, postgres.DefaultConfig)
 	defer tearDown(t)
 	defer checkTxClosure(t, 1, 0, 1)
 

--- a/statediff/indexer/database/sql/pgx_indexer_test.go
+++ b/statediff/indexer/database/sql/pgx_indexer_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func setupPGXIndexer(t *testing.T) {
-	db, err = postgres.SetupPGXDB()
+	db, err = postgres.SetupPGXDB(postgres.DefaultConfig)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/statediff/indexer/database/sql/postgres/config.go
+++ b/statediff/indexer/database/sql/postgres/config.go
@@ -81,6 +81,9 @@ type Config struct {
 
 	// toggle on/off upserts
 	Upsert bool
+
+	// toggle on/off CopyFrom
+	CopyFrom bool
 }
 
 // Type satisfies interfaces.Config

--- a/statediff/indexer/database/sql/postgres/database.go
+++ b/statediff/indexer/database/sql/postgres/database.go
@@ -121,3 +121,19 @@ func (db *DB) InsertKnownGapsStm() string {
 			ON CONFLICT (starting_block_number) DO UPDATE SET (ending_block_number, processing_key) = ($2, $4)
 			WHERE eth_meta.known_gaps.ending_block_number <= $2`
 }
+
+func (db *DB) StateTableName() []string {
+	return []string{"eth", "state_cids"}
+}
+
+func (db *DB) StorageTableName() []string {
+	return []string{"eth", "storage_cids"}
+}
+
+func (db *DB) StateColumnNames() []string {
+	return []string{"block_number", "header_id", "state_leaf_key", "cid", "state_path", "node_type", "diff", "mh_key"}
+}
+
+func (db *DB) StorageColumnNames() []string {
+	return []string{"block_number", "header_id", "state_path", "storage_leaf_key", "cid", "storage_path", "node_type", "diff", "mh_key"}
+}

--- a/statediff/indexer/database/sql/postgres/database.go
+++ b/statediff/indexer/database/sql/postgres/database.go
@@ -122,33 +122,49 @@ func (db *DB) InsertKnownGapsStm() string {
 			WHERE eth_meta.known_gaps.ending_block_number <= $2`
 }
 
-func (db *DB) StateTableName() []string {
-	return []string{"eth", "state_cids"}
+func (db *DB) AccountTableName() []string {
+	return []string{"eth", "state_accounts"}
+}
+func (db *DB) AccountColumnNames() []string {
+	return []string{"block_number", "header_id", "state_path", "balance", "nonce", "code_hash", "storage_root"}
 }
 
-func (db *DB) StorageTableName() []string {
-	return []string{"eth", "storage_cids"}
+func (db *DB) LogTableName() []string {
+	return []string{"eth", "log_cids"}
+}
+
+func (db *DB) LogColumnNames() []string {
+	return []string{"block_number", "header_id", "leaf_cid", "leaf_mh_key", "rct_id", "address", "index", "topic0", "topic1", "topic2", "topic3", "log_data"}
+}
+
+func (db *DB) RctTableName() []string {
+	return []string{"eth", "receipt_cids"}
+}
+
+func (db *DB) RctColumnNames() []string {
+	return []string{"block_number", "header_id", "tx_id", "leaf_cid", "contract", "contract_hash", "leaf_mh_key", "post_state", "post_status", "log_root"}
+}
+
+func (db *DB) StateTableName() []string {
+	return []string{"eth", "state_cids"}
 }
 
 func (db *DB) StateColumnNames() []string {
 	return []string{"block_number", "header_id", "state_leaf_key", "cid", "state_path", "node_type", "diff", "mh_key"}
 }
 
+func (db *DB) StorageTableName() []string {
+	return []string{"eth", "storage_cids"}
+}
+
 func (db *DB) StorageColumnNames() []string {
 	return []string{"block_number", "header_id", "state_path", "storage_leaf_key", "cid", "storage_path", "node_type", "diff", "mh_key"}
 }
 
-func (db *DB) LogsTableName() []string {
-	return []string{"eth", "log_cids"}
+func (db *DB) TxTableName() []string {
+	return []string{"eth", "transaction_cids"}
 }
 
-func (db *DB) LogsColumnNames() []string {
-	return []string{"block_number", "header_id", "leaf_cid", "leaf_mh_key", "rct_id", "address", "index", "topic0", "topic1", "topic2", "topic3", "log_data"}
-}
-
-func (db *DB) AccountTableName() []string {
-	return []string{"eth", "state_accounts"}
-}
-func (db *DB) AccountColumnNames() []string {
-	return []string{"block_number", "header_id", "state_path", "balance", "nonce", "code_hash", "storage_root"}
+func (db *DB) TxColumnNames() []string {
+	return []string{"block_number", "header_id", "tx_hash", "cid", "dst", "src", "index", "mh_key", "tx_data", "tx_type", "value"}
 }

--- a/statediff/indexer/database/sql/postgres/database.go
+++ b/statediff/indexer/database/sql/postgres/database.go
@@ -137,3 +137,18 @@ func (db *DB) StateColumnNames() []string {
 func (db *DB) StorageColumnNames() []string {
 	return []string{"block_number", "header_id", "state_path", "storage_leaf_key", "cid", "storage_path", "node_type", "diff", "mh_key"}
 }
+
+func (db *DB) LogsTableName() []string {
+	return []string{"eth", "log_cids"}
+}
+
+func (db *DB) LogsColumnNames() []string {
+	return []string{"block_number", "header_id", "leaf_cid", "leaf_mh_key", "rct_id", "address", "index", "topic0", "topic1", "topic2", "topic3", "log_data"}
+}
+
+func (db *DB) AccountTableName() []string {
+	return []string{"eth", "state_accounts"}
+}
+func (db *DB) AccountColumnNames() []string {
+	return []string{"block_number", "header_id", "state_path", "balance", "nonce", "code_hash", "storage_root"}
+}

--- a/statediff/indexer/database/sql/postgres/sqlx.go
+++ b/statediff/indexer/database/sql/postgres/sqlx.go
@@ -19,6 +19,7 @@ package postgres
 import (
 	"context"
 	coresql "database/sql"
+	"errors"
 	"time"
 
 	"github.com/jmoiron/sqlx"
@@ -119,6 +120,12 @@ func (driver *SQLXDriver) Context() context.Context {
 	return driver.ctx
 }
 
+// HasCopy satisfies sql.Database
+func (driver *SQLXDriver) UseCopyFrom() bool {
+	// sqlx does not currently support COPY.
+	return false
+}
+
 type sqlxStatsWrapper struct {
 	stats coresql.DBStats
 }
@@ -185,4 +192,8 @@ func (t sqlxTxWrapper) Commit(ctx context.Context) error {
 // Rollback satisfies sql.Tx
 func (t sqlxTxWrapper) Rollback(ctx context.Context) error {
 	return t.tx.Rollback()
+}
+
+func (t sqlxTxWrapper) CopyFrom(ctx context.Context, tableName []string, columnNames []string, rows [][]interface{}) (int64, error) {
+	return 0, errors.New("Unsupported Operation")
 }

--- a/statediff/indexer/database/sql/postgres/test_helpers.go
+++ b/statediff/indexer/database/sql/postgres/test_helpers.go
@@ -35,8 +35,8 @@ func SetupSQLXDB() (sql.Database, error) {
 }
 
 // SetupPGXDB is used to setup a pgx db for tests
-func SetupPGXDB() (sql.Database, error) {
-	driver, err := NewPGXDriver(context.Background(), DefaultConfig, node.Info{})
+func SetupPGXDB(config Config) (sql.Database, error) {
+	driver, err := NewPGXDriver(context.Background(), config, node.Info{})
 	if err != nil {
 		return nil, err
 	}

--- a/statediff/indexer/database/sql/writer.go
+++ b/statediff/indexer/database/sql/writer.go
@@ -89,7 +89,7 @@ func (w *Writer) upsertTransactionCID(tx Tx, transaction models.TxModel) error {
 			return insertError{"eth.transaction_cids", err, "COPY", transaction}
 		}
 
-		value, err := strconv.ParseInt(transaction.Value, 10, 64)
+		value, err := strconv.ParseFloat(transaction.Value, 64)
 		if err != nil {
 			return insertError{"eth.transaction_cids", err, "COPY", transaction}
 		}
@@ -317,6 +317,8 @@ func (w *Writer) upsertStorageCID(tx Tx, storageCID models.StorageNodeModel) err
 }
 
 func (w *Writer) useCopyForTx(tx Tx) bool {
+	// Using COPY instead of INSERT only makes much sense if also using a DelayedTx, so that operations
+	// can be collected over time and then all submitted within in a single TX.
 	if _, ok := tx.(*DelayedTx); ok {
 		return w.db.UseCopyFrom()
 	}

--- a/statediff/indexer/database/sql/writer.go
+++ b/statediff/indexer/database/sql/writer.go
@@ -150,14 +150,18 @@ func (w *Writer) upsertStateCID(tx Tx, stateNode models.StateNodeModel) error {
 	}
 	if w.db.UseCopyFrom() {
 		var row []interface{}
-		blockNum, _ := strconv.ParseInt(stateNode.BlockNumber, 10, 64)
+		blockNum, err := strconv.ParseInt(stateNode.BlockNumber, 10, 64)
+		if err != nil {
+			return insertError{"eth.state_cids", err, "COPY", stateNode}
+		}
+
 		row = append(row, blockNum, stateNode.HeaderID, stateKey, stateNode.CID,
 			stateNode.Path, stateNode.NodeType, true, stateNode.MhKey)
 
 		var rows [][]interface{}
 		rows = append(rows, row)
 
-		_, err := tx.CopyFrom(w.db.Context(), w.db.StateTableName(), w.db.StateColumnNames(), rows)
+		_, err = tx.CopyFrom(w.db.Context(), w.db.StateTableName(), w.db.StateColumnNames(), rows)
 		if err != nil {
 			return insertError{"eth.state_cids", err, "COPY", stateNode}
 		}
@@ -197,16 +201,20 @@ func (w *Writer) upsertStorageCID(tx Tx, storageCID models.StorageNodeModel) err
 	}
 	if w.db.UseCopyFrom() {
 		var row []interface{}
-		blockNum, _ := strconv.ParseInt(storageCID.BlockNumber, 10, 64)
+		blockNum, err := strconv.ParseInt(storageCID.BlockNumber, 10, 64)
+		if err != nil {
+			return insertError{"eth.storage_cids", err, "COPY", storageCID}
+		}
+
 		row = append(row, blockNum, storageCID.HeaderID, storageCID.StatePath, storageKey, storageCID.CID,
 			storageCID.Path, storageCID.NodeType, true, storageCID.MhKey)
 
 		var rows [][]interface{}
 		rows = append(rows, row)
 
-		_, err := tx.CopyFrom(w.db.Context(), w.db.StateTableName(), w.db.StateColumnNames(), rows)
+		_, err = tx.CopyFrom(w.db.Context(), w.db.StorageTableName(), w.db.StorageColumnNames(), rows)
 		if err != nil {
-			return insertError{"eth.state_cids", err, "COPY", storageCID}
+			return insertError{"eth.storage_cids", err, "COPY", storageCID}
 		}
 	} else {
 		_, err := tx.Exec(w.db.Context(), w.db.InsertStorageStm(),

--- a/statediff/indexer/database/sql/writer.go
+++ b/statediff/indexer/database/sql/writer.go
@@ -83,7 +83,6 @@ ON CONFLICT (tx_hash, header_id, block_number) DO NOTHING
 */
 func (w *Writer) upsertTransactionCID(tx Tx, transaction models.TxModel) error {
 	if w.useCopyForTx(tx) {
-		var row []interface{}
 		blockNum, err := strconv.ParseInt(transaction.BlockNumber, 10, 64)
 		if err != nil {
 			return insertError{"eth.transaction_cids", err, "COPY", transaction}
@@ -94,13 +93,9 @@ func (w *Writer) upsertTransactionCID(tx Tx, transaction models.TxModel) error {
 			return insertError{"eth.transaction_cids", err, "COPY", transaction}
 		}
 
-		row = append(row, blockNum, transaction.HeaderID, transaction.TxHash, transaction.CID, transaction.Dst, transaction.Src,
-			transaction.Index, transaction.MhKey, transaction.Data, int(transaction.Type), value)
-
-		var rows [][]interface{}
-		rows = append(rows, row)
-
-		_, err = tx.CopyFrom(w.db.Context(), w.db.TxTableName(), w.db.TxColumnNames(), rows)
+		_, err = tx.CopyFrom(w.db.Context(), w.db.TxTableName(), w.db.TxColumnNames(),
+			toRows(toValues(blockNum, transaction.HeaderID, transaction.TxHash, transaction.CID, transaction.Dst,
+				transaction.Src, transaction.Index, transaction.MhKey, transaction.Data, int(transaction.Type), value)))
 		if err != nil {
 			return insertError{"eth.transaction_cids", err, "COPY", transaction}
 		}
@@ -137,19 +132,14 @@ ON CONFLICT (tx_id, header_id, block_number) DO NOTHING
 */
 func (w *Writer) upsertReceiptCID(tx Tx, rct *models.ReceiptModel) error {
 	if w.useCopyForTx(tx) {
-		var row []interface{}
 		blockNum, err := strconv.ParseInt(rct.BlockNumber, 10, 64)
 		if err != nil {
 			return insertError{"eth.receipt_cids", err, "COPY", rct}
 		}
 
-		row = append(row, blockNum, rct.HeaderID, rct.TxID, rct.LeafCID, rct.Contract, rct.ContractHash,
-			rct.LeafMhKey, rct.PostState, int(rct.PostStatus), rct.LogRoot)
-
-		var rows [][]interface{}
-		rows = append(rows, row)
-
-		_, err = tx.CopyFrom(w.db.Context(), w.db.RctTableName(), w.db.RctColumnNames(), rows)
+		_, err = tx.CopyFrom(w.db.Context(), w.db.RctTableName(), w.db.RctColumnNames(),
+			toRows(toValues(blockNum, rct.HeaderID, rct.TxID, rct.LeafCID, rct.Contract, rct.ContractHash,
+				rct.LeafMhKey, rct.PostState, int(rct.PostStatus), rct.LogRoot)))
 		if err != nil {
 			return insertError{"eth.receipt_cids", err, "COPY", rct}
 		}
@@ -215,19 +205,14 @@ func (w *Writer) upsertStateCID(tx Tx, stateNode models.StateNodeModel) error {
 		stateKey = stateNode.StateKey
 	}
 	if w.useCopyForTx(tx) {
-		var row []interface{}
 		blockNum, err := strconv.ParseInt(stateNode.BlockNumber, 10, 64)
 		if err != nil {
 			return insertError{"eth.state_cids", err, "COPY", stateNode}
 		}
 
-		row = append(row, blockNum, stateNode.HeaderID, stateKey, stateNode.CID,
-			stateNode.Path, stateNode.NodeType, true, stateNode.MhKey)
-
-		var rows [][]interface{}
-		rows = append(rows, row)
-
-		_, err = tx.CopyFrom(w.db.Context(), w.db.StateTableName(), w.db.StateColumnNames(), rows)
+		_, err = tx.CopyFrom(w.db.Context(), w.db.StateTableName(), w.db.StateColumnNames(),
+			toRows(toValues(blockNum, stateNode.HeaderID, stateKey, stateNode.CID, stateNode.Path,
+				stateNode.NodeType, true, stateNode.MhKey)))
 		if err != nil {
 			return insertError{"eth.state_cids", err, "COPY", stateNode}
 		}
@@ -248,7 +233,6 @@ ON CONFLICT (header_id, state_path, block_number) DO NOTHING
 */
 func (w *Writer) upsertStateAccount(tx Tx, stateAccount models.StateAccountModel) error {
 	if w.useCopyForTx(tx) {
-		var row []interface{}
 		blockNum, err := strconv.ParseInt(stateAccount.BlockNumber, 10, 64)
 		if err != nil {
 			return insertError{"eth.state_accounts", err, "COPY", stateAccount}
@@ -258,13 +242,9 @@ func (w *Writer) upsertStateAccount(tx Tx, stateAccount models.StateAccountModel
 			return insertError{"eth.state_accounts", err, "COPY", stateAccount}
 		}
 
-		row = append(row, blockNum, stateAccount.HeaderID, stateAccount.StatePath, balance,
-			stateAccount.Nonce, stateAccount.CodeHash, stateAccount.StorageRoot)
-
-		var rows [][]interface{}
-		rows = append(rows, row)
-
-		_, err = tx.CopyFrom(w.db.Context(), w.db.AccountTableName(), w.db.AccountColumnNames(), rows)
+		_, err = tx.CopyFrom(w.db.Context(), w.db.AccountTableName(), w.db.AccountColumnNames(),
+			toRows(toValues(blockNum, stateAccount.HeaderID, stateAccount.StatePath, balance, stateAccount.Nonce,
+				stateAccount.CodeHash, stateAccount.StorageRoot)))
 		if err != nil {
 			return insertError{"eth.state_accounts", err, "COPY", stateAccount}
 		}
@@ -289,19 +269,14 @@ func (w *Writer) upsertStorageCID(tx Tx, storageCID models.StorageNodeModel) err
 		storageKey = storageCID.StorageKey
 	}
 	if w.useCopyForTx(tx) {
-		var row []interface{}
 		blockNum, err := strconv.ParseInt(storageCID.BlockNumber, 10, 64)
 		if err != nil {
 			return insertError{"eth.storage_cids", err, "COPY", storageCID}
 		}
 
-		row = append(row, blockNum, storageCID.HeaderID, storageCID.StatePath, storageKey, storageCID.CID,
-			storageCID.Path, storageCID.NodeType, true, storageCID.MhKey)
-
-		var rows [][]interface{}
-		rows = append(rows, row)
-
-		_, err = tx.CopyFrom(w.db.Context(), w.db.StorageTableName(), w.db.StorageColumnNames(), rows)
+		_, err = tx.CopyFrom(w.db.Context(), w.db.StorageTableName(), w.db.StorageColumnNames(),
+			toRows(toValues(blockNum, storageCID.HeaderID, storageCID.StatePath, storageKey, storageCID.CID,
+				storageCID.Path, storageCID.NodeType, true, storageCID.MhKey)))
 		if err != nil {
 			return insertError{"eth.storage_cids", err, "COPY", storageCID}
 		}
@@ -323,6 +298,16 @@ func (w *Writer) useCopyForTx(tx Tx) bool {
 		return w.db.UseCopyFrom()
 	}
 	return false
+}
+
+func toValues(args ...interface{}) []interface{} {
+	var row []interface{}
+	row = append(row, args...)
+	return row
+}
+
+func toRows(rows ...[]interface{}) [][]interface{} {
+	return rows
 }
 
 type insertError struct {


### PR DESCRIPTION
Use COPY rather than INSERT to minimize operations and round trips.  Previously, we averaged about 5K DB operations per block.  This should drop it to under 20.

The effect is visible below, reducing the DB write time per block on vulture from ~12s to ~1.2s.

The use of COPY is controlled by `--statediff.db.copyfrom=true|false`

<img width="1831" alt="Screenshot 2023-03-08 at 10 42 42 PM" src="https://user-images.githubusercontent.com/1649771/223919180-423da4ef-a15e-4578-8c63-eeab30da5711.png">
