### PR TITLE
Add timers/counters for LevelDB Get, Put, Has, and Delete.

### DIFF
--- a/ethdb/leveldb/leveldb.go
+++ b/ethdb/leveldb/leveldb.go
@@ -194,13 +194,17 @@ func (db *Database) Close() error {
 
 // Has retrieves if a key is present in the key-value store.
 func (db *Database) Has(key []byte) (bool, error) {
-	defer func(start time.Time) { db.hasTimer.UpdateSince(start) }(time.Now())
+	if nil != db.hasTimer {
+		defer func(start time.Time) { db.hasTimer.UpdateSince(start) }(time.Now())
+	}
 	return db.db.Has(key, nil)
 }
 
 // Get retrieves the given key if it's present in the key-value store.
 func (db *Database) Get(key []byte) ([]byte, error) {
-	defer func(start time.Time) { db.getTimer.UpdateSince(start) }(time.Now())
+	if nil != db.getTimer {
+		defer func(start time.Time) { db.getTimer.UpdateSince(start) }(time.Now())
+	}
 	dat, err := db.db.Get(key, nil)
 	if err != nil {
 		return nil, err
@@ -210,13 +214,17 @@ func (db *Database) Get(key []byte) ([]byte, error) {
 
 // Put inserts the given value into the key-value store.
 func (db *Database) Put(key []byte, value []byte) error {
-	defer func(start time.Time) { db.putTimer.UpdateSince(start) }(time.Now())
+	if nil != db.putTimer {
+		defer func(start time.Time) { db.putTimer.UpdateSince(start) }(time.Now())
+	}
 	return db.db.Put(key, value, nil)
 }
 
 // Delete removes the key from the key-value store.
 func (db *Database) Delete(key []byte) error {
-	defer func(start time.Time) { db.deleteTimer.UpdateSince(start) }(time.Now())
+	if nil != db.deleteTimer {
+		defer func(start time.Time) { db.deleteTimer.UpdateSince(start) }(time.Now())
+	}
 	return db.db.Delete(key, nil)
 }
 


### PR DESCRIPTION
Add timers/counters for LevelDB Get, Put, Has, and Delete:

```
❯ wget -O - -q http://localhost:6060/debug/metrics/prometheus  | grep 'chaindata_db_' | grep -v '#'
eth_db_chaindata_db_delete_time_count 2
eth_db_chaindata_db_delete_time {quantile="0.5"} 16402.5
eth_db_chaindata_db_delete_time {quantile="0.75"} 27420
eth_db_chaindata_db_delete_time {quantile="0.95"} 27420
eth_db_chaindata_db_delete_time {quantile="0.99"} 27420
eth_db_chaindata_db_delete_time {quantile="0.999"} 27420
eth_db_chaindata_db_delete_time {quantile="0.9999"} 27420
eth_db_chaindata_db_delete_time_total 32805
eth_db_chaindata_db_get_time_count 15795
eth_db_chaindata_db_get_time {quantile="0.5"} 8836
eth_db_chaindata_db_get_time {quantile="0.75"} 21940.25
eth_db_chaindata_db_get_time {quantile="0.95"} 60560.64999999995
eth_db_chaindata_db_get_time {quantile="0.99"} 151965.09
eth_db_chaindata_db_get_time {quantile="0.999"} 1.3177919370000018e+06
eth_db_chaindata_db_get_time {quantile="0.9999"} 1.332128e+06
eth_db_chaindata_db_get_time_total 315101202
eth_db_chaindata_db_has_time_count 3
eth_db_chaindata_db_has_time {quantile="0.5"} 43719
eth_db_chaindata_db_has_time {quantile="0.75"} 63825
eth_db_chaindata_db_has_time {quantile="0.95"} 63825
eth_db_chaindata_db_has_time {quantile="0.99"} 63825
eth_db_chaindata_db_has_time {quantile="0.999"} 63825
eth_db_chaindata_db_has_time {quantile="0.9999"} 63825
eth_db_chaindata_db_has_time_total 109919
eth_db_chaindata_db_put_time_count 731
eth_db_chaindata_db_put_time {quantile="0.5"} 44147
eth_db_chaindata_db_put_time {quantile="0.75"} 74190
eth_db_chaindata_db_put_time {quantile="0.95"} 169453.19999999998
eth_db_chaindata_db_put_time {quantile="0.99"} 935974.279999988
eth_db_chaindata_db_put_time {quantile="0.999"} 2.1057723e+07
eth_db_chaindata_db_put_time {quantile="0.9999"} 2.1057723e+07
eth_db_chaindata_db_put_time_total 79389515
```