### PR TITLE
Fix and test `WriteStateDiffAt`

### DIFF
--- a/statediff/api.go
+++ b/statediff/api.go
@@ -199,7 +199,7 @@ func (api *PublicStateDiffAPI) StreamWrites(ctx context.Context) (*rpc.Subscript
 				}
 			case err = <-rpcSub.Err():
 				if err != nil {
-					log.Error("State diff service rpcSub error: " + err.Error())
+					log.Error("statediff_StreamWrites RPC subscription error: " + err.Error())
 					return
 				}
 			case <-quitChan:

--- a/statediff/service.go
+++ b/statediff/service.go
@@ -226,6 +226,8 @@ func New(stack *node.Node, ethServ *eth.Ethereum, cfg *ethconfig.Config, params 
 		enableWriteLoop:   params.EnableWriteLoop,
 		numWorkers:        workers,
 		maxRetry:          defaultRetryLimit,
+		jobStatusSubs:     map[rpc.ID]statusSubscription{},
+		currentJobs:       map[uint64]JobID{},
 	}
 	stack.RegisterLifecycle(sds)
 	stack.RegisterAPIs(sds.APIs())
@@ -912,9 +914,6 @@ func (sds *Service) writeStateDiffWithRetry(block *types.Block, parentRoot commo
 func (sds *Service) SubscribeWriteStatus(id rpc.ID, sub chan<- JobStatus, quitChan chan<- bool) {
 	log.Info("Subscribing to job status updates", "subscription id", id)
 	sds.Lock()
-	if sds.jobStatusSubs == nil {
-		sds.jobStatusSubs = map[rpc.ID]statusSubscription{}
-	}
 	sds.jobStatusSubs[id] = statusSubscription{
 		statusChan: sub,
 		quitChan:   quitChan,

--- a/statediff/service.go
+++ b/statediff/service.go
@@ -160,8 +160,8 @@ type JobID uint64
 
 // JobStatus represents the status of a completed job
 type JobStatus struct {
-	id  JobID
-	err error
+	ID  JobID
+	Err error
 }
 
 type statusSubscription struct {

--- a/statediff/service.go
+++ b/statediff/service.go
@@ -185,6 +185,7 @@ func NewBlockCache(max uint) BlockCache {
 
 // New creates a new statediff.Service
 // func New(stack *node.Node, ethServ *eth.Ethereum, dbParams *DBParams, enableWriteLoop bool) error {
+// func New(stack *node.Node, blockChain *core.BlockChain, networkID uint64, params Config, backend ethapi.Backend) error {
 func New(stack *node.Node, ethServ *eth.Ethereum, cfg *ethconfig.Config, params Config, backend ethapi.Backend) error {
 	blockChain := ethServ.BlockChain()
 	var indexer interfaces.StateDiffIndexer
@@ -240,6 +241,37 @@ func New(stack *node.Node, ethServ *eth.Ethereum, cfg *ethconfig.Config, params 
 	}
 
 	return nil
+}
+
+func NewService(blockChain blockChain, cfg Config, backend ethapi.Backend, indexer interfaces.StateDiffIndexer) *Service {
+	workers := cfg.NumWorkers
+	if workers == 0 {
+		workers = 1
+	}
+
+	quitCh := make(chan bool)
+	sds := &Service{
+		Mutex:             sync.Mutex{},
+		BlockChain:        blockChain,
+		Builder:           NewBuilder(blockChain.StateCache()),
+		QuitChan:          quitCh,
+		Subscriptions:     make(map[common.Hash]map[rpc.ID]Subscription),
+		SubscriptionTypes: make(map[common.Hash]Params),
+		BlockCache:        NewBlockCache(workers),
+		BackendAPI:        backend,
+		WaitForSync:       cfg.WaitForSync,
+		indexer:           indexer,
+		enableWriteLoop:   cfg.EnableWriteLoop,
+		numWorkers:        workers,
+		maxRetry:          defaultRetryLimit,
+		jobStatusSubs:     map[rpc.ID]statusSubscription{},
+		currentJobs:       map[uint64]JobID{},
+	}
+
+	if indexer != nil {
+		indexer.ReportDBMetrics(10*time.Second, quitCh)
+	}
+	return sds
 }
 
 // Protocols exports the services p2p protocols, this service has none
@@ -885,7 +917,7 @@ func (sds *Service) writeStateDiff(block *types.Block, parentRoot common.Hash, p
 	}, params, output, codeOutput)
 	// TODO this anti-pattern needs to be sorted out eventually
 	if err := tx.Submit(err); err != nil {
-		return fmt.Errorf("batch transaction submission failed: %s", err.Error())
+		return fmt.Errorf("batch transaction submission failed: %w", err)
 	}
 
 	// allow dereferencing of parent, keep current locked as it should be the next parent

--- a/statediff/test_helpers/mocks/builder.go
+++ b/statediff/test_helpers/mocks/builder.go
@@ -43,7 +43,7 @@ func (builder *Builder) BuildStateDiffObject(args statediff.Args, params statedi
 
 // BuildStateDiffObject mock method
 func (builder *Builder) WriteStateDiffObject(args statediff.Args, params statediff.Params, output sdtypes.StateNodeSink, codeOutput sdtypes.CodeSink) error {
-	builder.StateRoots = sdtypes.StateRoots{OldStateRoot: args.OldStateRoot, NewStateRoot: args.NewStateRoot}
+	builder.Args = args
 	builder.Params = params
 
 	return builder.builderError

--- a/statediff/test_helpers/mocks/indexer.go
+++ b/statediff/test_helpers/mocks/indexer.go
@@ -32,9 +32,7 @@ var _ interfaces.Batch = &batch{}
 // StateDiffIndexer is a mock state diff indexer
 type StateDiffIndexer struct{}
 
-type batch struct {
-	sdi *StateDiffIndexer
-}
+type batch struct{}
 
 func (sdi *StateDiffIndexer) PushBlock(block *types.Block, receipts types.Receipts, totalDifficulty *big.Int) (interfaces.Batch, error) {
 	return &batch{}, nil

--- a/statediff/test_helpers/mocks/indexer.go
+++ b/statediff/test_helpers/mocks/indexer.go
@@ -27,15 +27,20 @@ import (
 )
 
 var _ interfaces.StateDiffIndexer = &StateDiffIndexer{}
+var _ interfaces.Batch = &batch{}
 
 // StateDiffIndexer is a mock state diff indexer
 type StateDiffIndexer struct{}
 
-func (sdi *StateDiffIndexer) PushBlock(block *types.Block, receipts types.Receipts, totalDifficulty *big.Int) (interfaces.Batch, error) {
-	return nil, nil
+type batch struct {
+	sdi *StateDiffIndexer
 }
 
-func (sdi *StateDiffIndexer) PushStateNode(tx interfaces.Batch, stateNode sdtypes.StateNode, headerID string) error {
+func (sdi *StateDiffIndexer) PushBlock(block *types.Block, receipts types.Receipts, totalDifficulty *big.Int) (interfaces.Batch, error) {
+	return &batch{}, nil
+}
+
+func (sdi *StateDiffIndexer) PushStateNode(txi interfaces.Batch, stateNode sdtypes.StateNode, headerID string) error {
 	return nil
 }
 
@@ -66,5 +71,9 @@ func (sdi *StateDiffIndexer) ClearWatchedAddresses() error {
 }
 
 func (sdi *StateDiffIndexer) Close() error {
+	return nil
+}
+
+func (tx *batch) Submit(err error) error {
 	return nil
 }


### PR DESCRIPTION
Make the `JobSatus` fields public so it's actually usable, fix and add a basic unit test for the method.

Resolves https://github.com/cerc-io/go-ethereum/issues/355
See https://github.com/cerc-io/go-ethereum/issues/356#issuecomment-1493438343