### PR TITLE
More fixes for async statediff

### DIFF
--- a/statediff/api.go
+++ b/statediff/api.go
@@ -183,10 +183,8 @@ func (api *PublicStateDiffAPI) StreamWrites(ctx context.Context) (*rpc.Subscript
 
 		var err error
 		defer func() {
-			if err != nil {
-				if err = api.sds.UnsubscribeWriteStatus(rpcSub.ID); err != nil {
-					log.Error("Failed to unsubscribe from job status stream: " + err.Error())
-				}
+			if err = api.sds.UnsubscribeWriteStatus(rpcSub.ID); err != nil {
+				log.Error("Failed to unsubscribe from job status stream: " + err.Error())
 			}
 		}()
 		// loop and await payloads and relay them to the subscriber with the notifier

--- a/statediff/service.go
+++ b/statediff/service.go
@@ -959,9 +959,6 @@ func (sds *Service) UnsubscribeWriteStatus(id rpc.ID) error {
 	sds.Lock()
 	close(sds.jobStatusSubs[id].quitChan)
 	delete(sds.jobStatusSubs, id)
-	if len(sds.jobStatusSubs) == 0 {
-		sds.jobStatusSubs = nil
-	}
 	sds.Unlock()
 	return nil
 }


### PR DESCRIPTION
Map was being deleted once it was empty

See https://github.com/cerc-io/go-ethereum/issues/356#issuecomment-1493438343