### PR TITLE
missing upsert clause for schema.TableIPLDBlock

### DIFF
--- a/statediff/builder.go
+++ b/statediff/builder.go
@@ -71,9 +71,9 @@ func StorageNodeAppender(nodes *[]types2.StorageLeafNode) types2.StorageNodeSink
 		return nil
 	}
 }
-func IPLDMappingAppender(codeAndCodeHashes *[]types2.IPLD) types2.IPLDSink {
+func IPLDMappingAppender(iplds *[]types2.IPLD) types2.IPLDSink {
 	return func(c types2.IPLD) error {
-		*codeAndCodeHashes = append(*codeAndCodeHashes, c)
+		*iplds = append(*iplds, c)
 		return nil
 	}
 }

--- a/statediff/indexer/shared/schema/schema.go
+++ b/statediff/indexer/shared/schema/schema.go
@@ -23,6 +23,7 @@ var TableIPLDBlock = Table{
 		{Name: "key", Type: Dtext},
 		{Name: "data", Type: Dbytea},
 	},
+	UpsertClause: OnConflict("block_number", "key"),
 }
 
 var TableNodeInfo = Table{


### PR DESCRIPTION
This doesn't cause any issues until this `schema` package is used as dependency in ipld-eth-state-snapshot (because here we always insert with the batch statement).