### PR TITLE
expose parent path from trie.Iterator

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ const (
 	VersionMajor = 1                       // Major version component of the current release
 	VersionMinor = 11                      // Minor version component of the current release
 	VersionPatch = 6                       // Patch version component of the current release
-	VersionMeta  = "statediff-5.0.2-alpha" // Version metadata to append to the version string
+	VersionMeta  = "statediff-5.0.3-alpha" // Version metadata to append to the version string
 )
 
 // Version holds the textual version string.


### PR DESCRIPTION
Necessary in order to generate selector suffixes (paths) for embedded/internalized leaf nodes. See https://github.com/cerc-io/go-ethereum/issues/255.