### PR TITLE
bump statediff meta version

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ const (
 	VersionMajor = 1                       // Major version component of the current release
 	VersionMinor = 11                      // Minor version component of the current release
 	VersionPatch = 5                       // Patch version component of the current release
-	VersionMeta  = "statediff-5.0.1-alpha" // Version metadata to append to the version string
+	VersionMeta  = "statediff-5.0.2-alpha" // Version metadata to append to the version string
 )
 
 // Version holds the textual version string.


### PR DESCRIPTION
Going to cut a release of the current v5 state before rebasing to v1.11.6