### PR TITLE
Port #368 back to v1.11.5-statediff-v5

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ const (
 	VersionMajor = 1                       // Major version component of the current release
 	VersionMinor = 11                      // Minor version component of the current release
 	VersionPatch = 5                       // Patch version component of the current release
-	VersionMeta  = "statediff-5.0.2-alpha" // Version metadata to append to the version string
+	VersionMeta  = "statediff-5.0.3-alpha" // Version metadata to append to the version string
 )
 
 // Version holds the textual version string.


### PR DESCRIPTION
Because that is the version that all downstream tooling with pending inflight updates use (Roy's work on propagating v5 updates to ipld-eth-db-validator; Thomas' work on chain-chunker; my work fixing ipld-eth-state-snapshot). I am of the opinion we should go through and bump all dependent repos up to 1.11.6 once these tasks have resolved/reached a steady state.