### PR TITLE
292: Backfill gaps in the recent past on startup when tracking head.

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -273,13 +273,15 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 			}
 		}
 		p := statediff.Config{
-			IndexerConfig:   indexerConfig,
-			ID:              nodeID,
-			ClientName:      clientName,
-			Context:         context.Background(),
-			EnableWriteLoop: ctx.Bool(utils.StateDiffWritingFlag.Name),
-			NumWorkers:      ctx.Uint(utils.StateDiffWorkersFlag.Name),
-			WaitForSync:     ctx.Bool(utils.StateDiffWaitForSync.Name),
+			IndexerConfig:           indexerConfig,
+			ID:                      nodeID,
+			ClientName:              clientName,
+			Context:                 context.Background(),
+			EnableWriteLoop:         ctx.Bool(utils.StateDiffWritingFlag.Name),
+			NumWorkers:              ctx.Uint(utils.StateDiffWorkersFlag.Name),
+			WaitForSync:             ctx.Bool(utils.StateDiffWaitForSync.Name),
+			BackfillCheckPastBlocks: ctx.Uint64(utils.StateDiffBackfillCheckPastBlocks.Name),
+			BackfillMaxHeadGap:      ctx.Uint64(utils.StateDiffBackfillMaxHeadGap.Name),
 		}
 		utils.RegisterStateDiffService(stack, eth, &cfg.Eth, p, backend)
 	}

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -176,6 +176,8 @@ var (
 		utils.StateDiffUpsert,
 		utils.StateDiffLogStatements,
 		utils.StateDiffCopyFrom,
+		utils.StateDiffBackfillCheckPastBlocks,
+		utils.StateDiffBackfillMaxHeadGap,
 		configFileFlag,
 	}, utils.NetworkFlags, utils.DatabasePathFlags)
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1120,6 +1120,16 @@ Please note that --` + MetricsHTTPFlag.Name + ` must be set to start the server.
 		Name:  "statediff.waitforsync",
 		Usage: "Should the statediff service wait for geth to catch up to the head of the chain?",
 	}
+	StateDiffBackfillCheckPastBlocks = &cli.Uint64Flag{
+		Name:  "statediff.backfillcheckpastblocks",
+		Usage: "The number of blocks behind the startup statediff position to check (and fill) for gaps when head tracking.",
+		Value: 7200,
+	}
+	StateDiffBackfillMaxHeadGap = &cli.Uint64Flag{
+		Name:  "statediff.backfillmaxheadgap",
+		Usage: "The maximum gap between the startup statediff and startup head positions that can be backfilled.",
+		Value: 7200,
+	}
 )
 
 var (

--- a/statediff/config.go
+++ b/statediff/config.go
@@ -36,6 +36,10 @@ type Config struct {
 	ClientName string
 	// Whether to enable writing state diffs directly to track blockchain head
 	EnableWriteLoop bool
+	// The maximum number of blocks to backfill when tracking head.
+	BackfillMaxHeadGap uint64
+	// The maximum number of blocks behind the startup position to check for gaps.
+	BackfillCheckPastBlocks uint64
 	// Size of the worker pool
 	NumWorkers uint
 	// Should the statediff service wait until geth has synced to the head of the blockchain?

--- a/statediff/indexer/database/dump/indexer.go
+++ b/statediff/indexer/database/dump/indexer.go
@@ -418,6 +418,18 @@ func (sdi *StateDiffIndexer) HasBlock(hash common.Hash, number uint64) (bool, er
 	return false, nil
 }
 
+// CurrentBlock returns the HeaderModel of the highest existing block in the output.
+// In the "dump" case, this is always nil.
+func (sdi *StateDiffIndexer) CurrentBlock() (*models.HeaderModel, error) {
+	return nil, nil
+}
+
+// DetectGaps returns a list of gaps in the output found within the specified block range.
+// In the "dump" case this is always nil.
+func (sdi *StateDiffIndexer) DetectGaps(beginBlockNumber uint64, endBlockNumber uint64) ([]*interfaces.BlockGap, error) {
+	return nil, nil
+}
+
 // Close satisfies io.Closer
 func (sdi *StateDiffIndexer) Close() error {
 	return sdi.dump.Close()

--- a/statediff/indexer/database/file/indexer.go
+++ b/statediff/indexer/database/file/indexer.go
@@ -462,13 +462,13 @@ func (sdi *StateDiffIndexer) PushIPLD(batch interfaces.Batch, ipld sdtypes.IPLD)
 }
 
 // CurrentBlock returns the HeaderModel of the highest existing block in the output.
-// In the "dump" case, this is always nil.
+// In the "file" case, this is always nil.
 func (sdi *StateDiffIndexer) CurrentBlock() (*models.HeaderModel, error) {
 	return nil, nil
 }
 
 // DetectGaps returns a list of gaps in the output found within the specified block range.
-// In the "dump" case this is always nil.
+// In the "file" case this is always nil.
 func (sdi *StateDiffIndexer) DetectGaps(beginBlockNumber uint64, endBlockNumber uint64) ([]*interfaces.BlockGap, error) {
 	return nil, nil
 }

--- a/statediff/indexer/database/file/indexer.go
+++ b/statediff/indexer/database/file/indexer.go
@@ -461,6 +461,18 @@ func (sdi *StateDiffIndexer) PushIPLD(batch interfaces.Batch, ipld sdtypes.IPLD)
 	return nil
 }
 
+// CurrentBlock returns the HeaderModel of the highest existing block in the output.
+// In the "dump" case, this is always nil.
+func (sdi *StateDiffIndexer) CurrentBlock() (*models.HeaderModel, error) {
+	return nil, nil
+}
+
+// DetectGaps returns a list of gaps in the output found within the specified block range.
+// In the "dump" case this is always nil.
+func (sdi *StateDiffIndexer) DetectGaps(beginBlockNumber uint64, endBlockNumber uint64) ([]*interfaces.BlockGap, error) {
+	return nil, nil
+}
+
 // HasBlock checks whether the indicated block already exists in the output.
 // In the "file" case this is presumed to be false.
 func (sdi *StateDiffIndexer) HasBlock(hash common.Hash, number uint64) (bool, error) {

--- a/statediff/indexer/database/sql/indexer.go
+++ b/statediff/indexer/database/sql/indexer.go
@@ -219,9 +219,19 @@ func (sdi *StateDiffIndexer) PushBlock(block *types.Block, receipts types.Receip
 	return blockTx, err
 }
 
+// CurrentBlock returns the HeaderModel of the highest existing block in the database.
+func (sdi *StateDiffIndexer) CurrentBlock() (*models.HeaderModel, error) {
+	return sdi.dbWriter.maxHeader()
+}
+
 // HasBlock checks whether the indicated block already exists in the database.
 func (sdi *StateDiffIndexer) HasBlock(hash common.Hash, number uint64) (bool, error) {
 	return sdi.dbWriter.hasHeader(hash, number)
+}
+
+// DetectGaps returns a list of gaps in the database found within the specified block range.
+func (sdi *StateDiffIndexer) DetectGaps(beginBlockNumber uint64, endBlockNumber uint64) ([]*interfaces.BlockGap, error) {
+	return sdi.dbWriter.detectGaps(beginBlockNumber, endBlockNumber)
 }
 
 // processHeader publishes and indexes a header IPLD in Postgres

--- a/statediff/indexer/database/sql/interfaces.go
+++ b/statediff/indexer/database/sql/interfaces.go
@@ -45,6 +45,7 @@ type Driver interface {
 
 // Statements interface to accommodate different SQL query syntax
 type Statements interface {
+	MaxHeaderStm() string
 	ExistsHeaderStm() string
 	InsertHeaderStm() string
 	InsertUncleStm() string

--- a/statediff/indexer/database/sql/interfaces.go
+++ b/statediff/indexer/database/sql/interfaces.go
@@ -45,6 +45,7 @@ type Driver interface {
 
 // Statements interface to accommodate different SQL query syntax
 type Statements interface {
+	DetectGapsStm() string
 	MaxHeaderStm() string
 	ExistsHeaderStm() string
 	InsertHeaderStm() string

--- a/statediff/indexer/database/sql/postgres/database.go
+++ b/statediff/indexer/database/sql/postgres/database.go
@@ -41,12 +41,19 @@ type DB struct {
 	sql.Driver
 }
 
+// MaxHeaderStm satisfies the sql.Statements interface
 func (db *DB) MaxHeaderStm() string {
 	return fmt.Sprintf("SELECT block_number, block_hash, parent_hash, cid, td, node_ids, reward, state_root, tx_root, receipt_root, uncles_hash, bloom, timestamp, coinbase FROM %s ORDER BY block_number DESC LIMIT 1", schema.TableHeader.Name)
 }
 
+// ExistsHeaderStm satisfies the sql.Statements interface
 func (db *DB) ExistsHeaderStm() string {
 	return fmt.Sprintf("SELECT EXISTS(SELECT 1 from %s WHERE block_number = $1::BIGINT AND block_hash = $2::TEXT LIMIT 1)", schema.TableHeader.Name)
+}
+
+// DetectGapsStm satisfies the sql.Statements interface
+func (db *DB) DetectGapsStm() string {
+	return fmt.Sprintf("SELECT block_number + 1 AS first_missing, (next_bn - 1) AS last_missing FROM (SELECT block_number, LEAD(block_number) OVER (ORDER BY block_number) AS next_bn FROM %s WHERE block_number >= $1::BIGINT AND block_number <= $2::BIGINT) h WHERE next_bn > block_number + 1", schema.TableHeader.Name)
 }
 
 // InsertHeaderStm satisfies the sql.Statements interface

--- a/statediff/indexer/database/sql/postgres/database.go
+++ b/statediff/indexer/database/sql/postgres/database.go
@@ -41,8 +41,12 @@ type DB struct {
 	sql.Driver
 }
 
+func (db *DB) MaxHeaderStm() string {
+	return fmt.Sprintf("SELECT block_number, block_hash, parent_hash, cid, td, node_ids, reward, state_root, tx_root, receipt_root, uncles_hash, bloom, timestamp, coinbase FROM %s ORDER BY block_number DESC LIMIT 1", schema.TableHeader.Name)
+}
+
 func (db *DB) ExistsHeaderStm() string {
-	return fmt.Sprintf("SELECT EXISTS(SELECT 1 from %s WHERE block_number = $1 AND block_hash = $2 LIMIT 1)", schema.TableHeader.Name)
+	return fmt.Sprintf("SELECT EXISTS(SELECT 1 from %s WHERE block_number = $1::BIGINT AND block_hash = $2::TEXT LIMIT 1)", schema.TableHeader.Name)
 }
 
 // InsertHeaderStm satisfies the sql.Statements interface

--- a/statediff/indexer/database/sql/writer.go
+++ b/statediff/indexer/database/sql/writer.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/ethereum/go-ethereum/statediff/indexer/interfaces"
+
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/jackc/pgtype"
@@ -48,9 +50,55 @@ func (w *Writer) Close() error {
 	return w.db.Close()
 }
 
+// hashHeader returns true if a matching hash+number record exists in the database, else false.
 func (w *Writer) hasHeader(blockHash common.Hash, blockNumber uint64) (exists bool, err error) {
-	err = w.db.QueryRow(w.db.Context(), w.db.ExistsHeaderStm(), blockNumber, blockHash.String()).Scan(&exists)
+	// pgx misdetects the parameter OIDs and selects int8, which can overflow.
+	// unfortunately there is no good place to override it, so it is safer to pass the uint64s as text
+	// and let PG handle the cast
+	err = w.db.QueryRow(w.db.Context(), w.db.ExistsHeaderStm(), strconv.FormatUint(blockNumber, 10), blockHash.String()).Scan(&exists)
 	return exists, err
+}
+
+// detectGaps returns a list of BlockGaps detected within the specified block range
+// For example, if the database contains blocks the overall range 1000:2000, but is missing blocks 1110:1230 and 1380
+// it would return [{FirstMissing: 1110, LastMissing: 1230}, {FirstMissing: 1380, LastMissing: 1380}]
+func (w *Writer) detectGaps(beginBlockNumber uint64, endBlockNumber uint64) ([]*interfaces.BlockGap, error) {
+	pgStm := "SELECT block_number + 1 AS first_missing, (next_bn - 1) AS last_missing FROM (SELECT block_number, LEAD(block_number) OVER (ORDER BY block_number) AS next_bn FROM eth.header_cids WHERE block_number >= $1::BIGINT AND block_number <= $2::BIGINT) h WHERE next_bn > block_number + 1"
+	var gaps []*interfaces.BlockGap
+	// pgx misdetects the parameter OIDs and selects int8, which can overflow.
+	// unfortunately there is no good place to override it, so it is safer to pass the uint64s as text
+	// and let PG handle the cast
+	err := w.db.Select(w.db.Context(), &gaps, pgStm, strconv.FormatUint(beginBlockNumber, 10), strconv.FormatUint(endBlockNumber, 10))
+	return gaps, err
+}
+
+/*
+SELECT block_number, block_hash, parent_hash, cid, td, node_ids, reward, state_root, tx_root, receipt_root, uncles_hash, bloom, timestamp, coinbase FROM %s ORDER BY block_number DESC LIMIT 1
+*/
+func (w *Writer) maxHeader() (*models.HeaderModel, error) {
+	var model models.HeaderModel
+	var err error
+	var number, td, reward uint64
+	err = w.db.QueryRow(w.db.Context(), w.db.MaxHeaderStm()).Scan(
+		&number,
+		&model.BlockHash,
+		&model.ParentHash,
+		&model.CID,
+		&td,
+		&model.NodeIDs,
+		&reward,
+		&model.StateRoot,
+		&model.TxRoot,
+		&model.RctRoot,
+		&model.UnclesHash,
+		&model.Bloom,
+		&model.Timestamp,
+		&model.Coinbase,
+	)
+	model.BlockNumber = strconv.FormatUint(number, 10)
+	model.TotalDifficulty = strconv.FormatUint(td, 10)
+	model.Reward = strconv.FormatUint(reward, 10)
+	return &model, err
 }
 
 /*

--- a/statediff/indexer/database/sql/writer.go
+++ b/statediff/indexer/database/sql/writer.go
@@ -50,7 +50,7 @@ func (w *Writer) Close() error {
 	return w.db.Close()
 }
 
-// hashHeader returns true if a matching hash+number record exists in the database, else false.
+// hasHeader returns true if a matching hash+number record exists in the database, else false.
 func (w *Writer) hasHeader(blockHash common.Hash, blockNumber uint64) (exists bool, err error) {
 	// pgx misdetects the parameter OIDs and selects int8, which can overflow.
 	// unfortunately there is no good place to override it, so it is safer to pass the uint64s as text
@@ -63,18 +63,16 @@ func (w *Writer) hasHeader(blockHash common.Hash, blockNumber uint64) (exists bo
 // For example, if the database contains blocks the overall range 1000:2000, but is missing blocks 1110:1230 and 1380
 // it would return [{FirstMissing: 1110, LastMissing: 1230}, {FirstMissing: 1380, LastMissing: 1380}]
 func (w *Writer) detectGaps(beginBlockNumber uint64, endBlockNumber uint64) ([]*interfaces.BlockGap, error) {
-	pgStm := "SELECT block_number + 1 AS first_missing, (next_bn - 1) AS last_missing FROM (SELECT block_number, LEAD(block_number) OVER (ORDER BY block_number) AS next_bn FROM eth.header_cids WHERE block_number >= $1::BIGINT AND block_number <= $2::BIGINT) h WHERE next_bn > block_number + 1"
 	var gaps []*interfaces.BlockGap
 	// pgx misdetects the parameter OIDs and selects int8, which can overflow.
 	// unfortunately there is no good place to override it, so it is safer to pass the uint64s as text
 	// and let PG handle the cast
-	err := w.db.Select(w.db.Context(), &gaps, pgStm, strconv.FormatUint(beginBlockNumber, 10), strconv.FormatUint(endBlockNumber, 10))
+	err := w.db.Select(w.db.Context(), &gaps, w.db.DetectGapsStm(), strconv.FormatUint(beginBlockNumber, 10), strconv.FormatUint(endBlockNumber, 10))
 	return gaps, err
 }
 
-/*
-SELECT block_number, block_hash, parent_hash, cid, td, node_ids, reward, state_root, tx_root, receipt_root, uncles_hash, bloom, timestamp, coinbase FROM %s ORDER BY block_number DESC LIMIT 1
-*/
+// maxHeader returns the header for the highest block number in the database.
+// SELECT block_number, block_hash, parent_hash, cid, td, node_ids, reward, state_root, tx_root, receipt_root, uncles_hash, bloom, timestamp, coinbase FROM %s ORDER BY block_number DESC LIMIT 1
 func (w *Writer) maxHeader() (*models.HeaderModel, error) {
 	var model models.HeaderModel
 	var err error

--- a/statediff/indexer/interfaces/interfaces.go
+++ b/statediff/indexer/interfaces/interfaces.go
@@ -21,6 +21,8 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/ethereum/go-ethereum/statediff/indexer/models"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/statediff/indexer/shared"
@@ -29,6 +31,8 @@ import (
 
 // StateDiffIndexer interface required to index statediff data
 type StateDiffIndexer interface {
+	DetectGaps(beginBlock uint64, endBlock uint64) ([]*BlockGap, error)
+	CurrentBlock() (*models.HeaderModel, error)
 	HasBlock(hash common.Hash, number uint64) (bool, error)
 	PushBlock(block *types.Block, receipts types.Receipts, totalDifficulty *big.Int) (Batch, error)
 	PushStateNode(tx Batch, stateNode sdtypes.StateLeafNode, headerID string) error
@@ -53,4 +57,10 @@ type Batch interface {
 // Config used to configure different underlying implementations
 type Config interface {
 	Type() shared.DBType
+}
+
+// Used to represent a gap in statediffed blocks
+type BlockGap struct {
+	FirstMissing uint64 `json:"firstMissing"`
+	LastMissing  uint64 `json:"lastMissing"`
 }

--- a/statediff/service.go
+++ b/statediff/service.go
@@ -1211,7 +1211,7 @@ func (sds *Service) backfillHeadGap(indexerBlockNumber uint64, chainBlockNumber 
 		}(i)
 	}
 
-	for bn := indexerBlockNumber; bn <= chainBlockNumber; bn++ {
+	for bn := indexerBlockNumber + 1; bn <= chainBlockNumber; bn++ {
 		ch <- bn
 	}
 	close(ch)

--- a/statediff/service.go
+++ b/statediff/service.go
@@ -1187,7 +1187,7 @@ func (sds *Service) Backfill() {
 func (sds *Service) backfillHeadGap(indexerBlockNumber uint64, chainBlockNumber uint64) {
 	headGap := chainBlockNumber - indexerBlockNumber
 	var ch = make(chan uint64, headGap)
-	for bn := indexerBlockNumber; bn < chainBlockNumber; bn++ {
+	for bn := indexerBlockNumber; bn <= chainBlockNumber; bn++ {
 		ch <- bn
 	}
 

--- a/statediff/test_helpers/mocks/indexer.go
+++ b/statediff/test_helpers/mocks/indexer.go
@@ -17,9 +17,10 @@
 package mocks
 
 import (
-	"github.com/ethereum/go-ethereum/statediff/indexer/models"
 	"math/big"
 	"time"
+
+	"github.com/ethereum/go-ethereum/statediff/indexer/models"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"

--- a/statediff/test_helpers/mocks/indexer.go
+++ b/statediff/test_helpers/mocks/indexer.go
@@ -17,6 +17,7 @@
 package mocks
 
 import (
+	"github.com/ethereum/go-ethereum/statediff/indexer/models"
 	"math/big"
 	"time"
 
@@ -31,6 +32,14 @@ var _ interfaces.Batch = &batch{}
 
 // StateDiffIndexer is a mock state diff indexer
 type StateDiffIndexer struct{}
+
+func (sdi *StateDiffIndexer) DetectGaps(beginBlock uint64, endBlock uint64) ([]*interfaces.BlockGap, error) {
+	return nil, nil
+}
+
+func (sdi *StateDiffIndexer) CurrentBlock() (*models.HeaderModel, error) {
+	return nil, nil
+}
 
 type batch struct{}
 


### PR DESCRIPTION
This adds a new `Backfill` check which is run at startup, which attempts to recover from two sorts of gaps which can occur when tracking head:

1) A contiguous gap from the last statediff position to the current head position.  Something like this can happen if statediffs are in-flight when geth is terminated, or if there is an error which prevents writing statediffs but not syncing the chain (eg, the DB goes down).  On startup then, we might notice that the current chain block is 2500, but the current statediff position is only 2498.  The _next_ ChainEvent we can expect to see will be at 2501, so we want to trigger statediffing of 2498, 2499, and 2500.

2) Discontiguous gaps in the recent past.  These can happen from temporary errors (eg, a momentary disruption in DB connectivity) or if the process is terminated with in-flight statediffs that completed out-of-order.  Eg, block 2500 got written but 2498 and 2499 were still in-flight, leaving a sequence like:  2496, 2497, 2500, ...  In this scenario, the statediff and chain positions are in sync, but we still need to plug the hole behind the current position.

I set default limits of 7200 blocks (~1 day) in both cases.  If the statediff position is more than 7200 blocks behind head, it will not attempt to backfill and will instead log an error.  When looking for gaps, it will look no further back than 7200 blocks from the current statediff position.  Both are configurable.

To handle more extreme situations, we also have `chain-chunker fillgap` which can detect and fill gaps across an arbitrary range.

Tests: https://git.vdb.to/cerc-io/system-tests/commit/aa53b8abcb981688d45a5e453338b9026ad43314