### PR TITLE
396: Don't skip any blocks if the head of the chain advances by more than one block.

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1127,7 +1127,7 @@ Please note that --` + MetricsHTTPFlag.Name + ` must be set to start the server.
 	}
 	StateDiffBackfillMaxHeadGap = &cli.Uint64Flag{
 		Name:  "statediff.backfillmaxheadgap",
-		Usage: "The maximum gap between the startup statediff and startup head positions that can be backfilled.",
+		Usage: "The maximum gap between the current statediff and head positions that can be backfilled.",
 		Value: 7200,
 	}
 )

--- a/statediff/service.go
+++ b/statediff/service.go
@@ -468,6 +468,8 @@ func (sds *Service) Loop(chainEventCh chan core.ChainEvent) {
 		select {
 		//Notify chain event channel of events
 		case chainEvent := <-chainEventCh:
+			// TODO: Do we need to track the last streamed block as we do for the WriteLoop  so that we can detect
+			// and plug any gaps in the events?  If not, we risk presenting an incomplete record.
 			defaultStatediffMetrics.serviceLoopChannelLen.Update(int64(len(chainEventCh)))
 			log.Debug("Loop(): chain event received", "event", chainEvent)
 			// if we don't have any subscribers, do not process a statediff

--- a/statediff/service.go
+++ b/statediff/service.go
@@ -360,24 +360,24 @@ func (sds *Service) WriteLoop(chainEventCh chan core.ChainEvent) {
 				if nextHeight > lastHeight {
 					distance := nextHeight - lastHeight
 					if distance == 1 {
-						log.Info("WriteLoop: received expected block", "next height", nextHeight, "last height", lastHeight)
+						log.Info("WriteLoop: received expected block", "block height", nextHeight, "last height", lastHeight)
 						blockFwd <- chainEvent.Block
 						defaultStatediffMetrics.lastEventHeight.Update(int64(nextHeight))
 					} else {
-						log.Warn("WriteLoop: received unexpected block from the future", "next height", nextHeight, "last height", lastHeight)
+						log.Warn("WriteLoop: received unexpected block from the future", "block height", nextHeight, "last height", lastHeight)
 						if distance <= sds.backfillMaxHeadGap {
 							for i := lastHeight + 1; i < nextHeight; i++ {
-								log.Info("WriteLoop: backfilling gap to head", "block", i, "next height", nextHeight, "last height", lastHeight, "gap", distance)
+								log.Info("WriteLoop: backfilling gap to head", "block", i, "block height", nextHeight, "last height", lastHeight)
 								blockFwd <- sds.BlockChain.GetBlockByNumber(i)
 							}
 						} else {
-							log.Warn("WriteLoop: gap to head too large to backfill", "next height", nextHeight, "last height", lastHeight, "gap", distance)
+							log.Warn("WriteLoop: gap to head too large to backfill", "block height", nextHeight, "last height", lastHeight, "gap", distance)
 						}
 						blockFwd <- chainEvent.Block
 						defaultStatediffMetrics.lastEventHeight.Update(int64(nextHeight))
 					}
 				} else {
-					log.Warn("WriteLoop: received unexpected block from the past", "next height", nextHeight, "last height", lastHeight)
+					log.Warn("WriteLoop: received unexpected block from the past", "block height", nextHeight, "last height", lastHeight)
 					blockFwd <- chainEvent.Block
 				}
 				defaultStatediffMetrics.writeLoopChannelLen.Update(int64(len(chainEventCh)))

--- a/statediff/service.go
+++ b/statediff/service.go
@@ -1218,6 +1218,7 @@ func (sds *Service) backfillDetectedGaps(blockGaps []*interfaces.BlockGap) {
 	wg.Wait()
 }
 
+// currentPosition returns the current block height for both the BlockChain and the statediff indexer.
 func (sds *Service) currentPosition() servicePosition {
 	ret := servicePosition{}
 	chainBlock := sds.BlockChain.CurrentBlock()


### PR DESCRIPTION
As https://github.com/cerc-io/go-ethereum/issues/396 shows, we can get scenarios when the chain advances by more than a single block, but the event which is seen by the WriteLoop will only be for the new head block--however many blocks in advance it is--allowing gaps to open in the statediffing.

This code will detect and trigger statediffing for the skipped blocks.  The functionality is similar to the previous "head gap" filling code.  Similar enough that we are able to remove that code and allow this to cover both cases.